### PR TITLE
feat: enhance docs to match site aesthetic

### DIFF
--- a/docs/docs/index.html
+++ b/docs/docs/index.html
@@ -5,19 +5,23 @@
   <meta name="viewport" content="width=device-width, initial-scale=1.0">
   <title>rinha2-back-end-go - Documentation</title>
   <meta name="description" content="Go 1.23 implementation of Rinha de Backend 2024/Q1 — minimal single-file API built for performance under constraints">
+  <link href="https://fonts.googleapis.com/css2?family=Fira+Code:wght@300;400;600;700&display=swap" rel="stylesheet">
   <style>
     :root {
-      --bg: #0a0a0a;
-      --sidebar-bg: #111111;
-      --text-primary: #ededed;
-      --text-muted: #888888;
-      --text-body: #c8c8c8;
-      --accent: #7c6af7;
-      --accent-hover: #9b8df9;
-      --code-bg: #1e1e2e;
-      --code-text: #cdd6f4;
-      --border: #1f1f2e;
-      --code-border: #2a2a3e;
+      --bg: #0c1f1f;
+      --sidebar-bg: #0a1818;
+      --accent: #00ADD8;
+      --accent-glow: #5DC9E2;
+      --text: #f0fdfd;
+      --text-muted: #8ebbbc;
+      --border: #1c4040;
+      --surface: #0d2424;
+      --surface-hover: #1a3535;
+      --text-primary: var(--text);
+      --text-body: var(--text);
+      --code-bg: var(--surface);
+      --code-text: var(--text);
+      --code-border: var(--border);
       --sidebar-width: 260px;
     }
 
@@ -25,13 +29,15 @@
     
     html {
       scroll-behavior: smooth;
-      font-family: -apple-system, BlinkMacSystemFont, "Segoe UI", Roboto, Helvetica, Arial, sans-serif;
+      font-family: 'Fira Code', monospace;
     }
     
     body {
       margin: 0;
       padding: 0;
       background: var(--bg);
+      background-image: radial-gradient(circle, rgba(93,201,226,0.07) 1px, transparent 1px);
+      background-size: 22px 22px;
       color: var(--text-primary);
       display: flex;
     }
@@ -130,7 +136,7 @@
 
     .nav-item.active {
       color: var(--accent);
-      background: rgba(124, 106, 247, 0.1);
+      background: rgba(0, 173, 216, 0.1);
       font-weight: 500;
     }
 
@@ -229,7 +235,7 @@
     }
 
     code {
-      font-family: 'JetBrains Mono', 'Fira Code', monospace;
+      font-family: 'Fira Code', monospace;
       background: var(--code-bg);
       color: var(--code-text);
       border-radius: 4px;
@@ -254,7 +260,7 @@
     }
 
     th {
-      background: #1a1a2e;
+      background: var(--sidebar-bg);
       color: var(--text-primary);
       font-weight: 600;
       border-bottom: 1px solid var(--border);
@@ -305,7 +311,7 @@
     }
     
     .search-highlight {
-      background: rgba(124, 106, 247, 0.3);
+      background: rgba(0, 173, 216, 0.3);
       border-radius: 2px;
       padding: 0 2px;
     }
@@ -407,6 +413,7 @@
 </ul>
     </div>
     <div class="sidebar-footer">
+      <a href="../" class="back-home">← Back to home</a>
       <a href="https://github.com/jonathanperis/rinha2-back-end-go" target="_blank" rel="noopener noreferrer">View on GitHub</a>
       <div>Built by Jonathan Peris</div>
     </div>


### PR DESCRIPTION
## Summary

- Restyled `docs/docs/index.html` to visually match the landing page aesthetic
- Updated fonts, color scheme, background effects, and CSS custom properties
- Added `← Back to home` navigation link in sidebar footer
- Wiki content and JavaScript functionality unchanged

## Changes
- Google Fonts updated to match landing page typography
- CSS variables replaced (background, sidebar, accent, text, border colors)
- Background effects applied (grid/dot/scanlines per repo's design language)
- All purple `#7c6af7` remnants replaced with repo-specific accent colors