### PR TITLE
ci: add workflow_dispatch to Deploy Docs

### DIFF
--- a/.github/workflows/deploy-docs.yml
+++ b/.github/workflows/deploy-docs.yml
@@ -1,6 +1,7 @@
 name: Deploy Docs
 
 on:
+  workflow_dispatch:
   push:
     branches: [main]
     paths-ignore:


### PR DESCRIPTION
Add `workflow_dispatch` trigger to Deploy Docs workflow so it can be manually triggered.