### PR TITLE
fix: theme docs template to match site aesthetic

### DIFF
--- a/.github/docs-template.html
+++ b/.github/docs-template.html
@@ -5,19 +5,23 @@
   <meta name="viewport" content="width=device-width, initial-scale=1.0">
   <title>{{TITLE}} - Documentation</title>
   <meta name="description" content="{{DESCRIPTION}}">
+  <link href="https://fonts.googleapis.com/css2?family=Fira+Code:wght@300;400;600;700&display=swap" rel="stylesheet">
   <style>
     :root {
-      --bg: #0a0a0a;
-      --sidebar-bg: #111111;
-      --text-primary: #ededed;
-      --text-muted: #888888;
-      --text-body: #c8c8c8;
-      --accent: #7c6af7;
-      --accent-hover: #9b8df9;
-      --code-bg: #1e1e2e;
-      --code-text: #cdd6f4;
-      --border: #1f1f2e;
-      --code-border: #2a2a3e;
+      --bg: #0c1f1f;
+      --sidebar-bg: #0a1818;
+      --accent: #00ADD8;
+      --accent-glow: #5DC9E2;
+      --text: #f0fdfd;
+      --text-muted: #8ebbbc;
+      --border: #1c4040;
+      --surface: #0d2424;
+      --surface-hover: #1a3535;
+      --text-primary: var(--text);
+      --text-body: var(--text);
+      --code-bg: var(--surface);
+      --code-text: var(--text);
+      --code-border: var(--border);
       --sidebar-width: 260px;
     }
 
@@ -25,13 +29,15 @@
     
     html {
       scroll-behavior: smooth;
-      font-family: -apple-system, BlinkMacSystemFont, "Segoe UI", Roboto, Helvetica, Arial, sans-serif;
+      font-family: 'Fira Code', monospace;
     }
     
     body {
       margin: 0;
       padding: 0;
       background: var(--bg);
+      background-image: radial-gradient(circle, rgba(93,201,226,0.07) 1px, transparent 1px);
+      background-size: 22px 22px;
       color: var(--text-primary);
       display: flex;
     }
@@ -130,7 +136,7 @@
 
     .nav-item.active {
       color: var(--accent);
-      background: rgba(124, 106, 247, 0.1);
+      background: rgba(0, 173, 216, 0.1);
       font-weight: 500;
     }
 
@@ -229,7 +235,7 @@
     }
 
     code {
-      font-family: 'JetBrains Mono', 'Fira Code', monospace;
+      font-family: 'Fira Code', monospace;
       background: var(--code-bg);
       color: var(--code-text);
       border-radius: 4px;
@@ -254,7 +260,7 @@
     }
 
     th {
-      background: #1a1a2e;
+      background: var(--sidebar-bg);
       color: var(--text-primary);
       font-weight: 600;
       border-bottom: 1px solid var(--border);
@@ -305,7 +311,7 @@
     }
     
     .search-highlight {
-      background: rgba(124, 106, 247, 0.3);
+      background: rgba(0, 173, 216, 0.3);
       border-radius: 2px;
       padding: 0 2px;
     }
@@ -400,6 +406,7 @@
       {{SIDEBAR_NAV}}
     </div>
     <div class="sidebar-footer">
+      <a href="../" class="back-home">← Back to home</a>
       <a href="{{GITHUB_URL}}" target="_blank" rel="noopener noreferrer">View on GitHub</a>
       <div>Built by Jonathan Peris</div>
     </div>


### PR DESCRIPTION
## Summary
- Updates `.github/docs-template.html` with Go-themed colors (cyan `#00ADD8`), Fira Code font, and dotted background pattern
- Adds "Back to home" link in the docs sidebar footer
- Fixes issue where `deploy-docs` workflow was regenerating docs with the generic purple template

## Test plan
- [ ] Merge PR → deploy-docs workflow triggers and regenerates `docs/docs/index.html`
- [ ] Verify https://jonathanperis.github.io/rinha2-back-end-go/docs/ shows Go-themed design

🤖 Generated with [Claude Code](https://claude.com/claude-code)