### PR TITLE
fix: use go-version-file instead of hardcoded 1.24.1 (go.mod requires 1.25.0)

### DIFF
--- a/.github/workflows/build-check.yml
+++ b/.github/workflows/build-check.yml
@@ -7,8 +7,8 @@ on:
   pull_request:
     branches:
       - main
-
   workflow_dispatch:
+
 jobs:
   setup-build-test:
     runs-on: ubuntu-latest
@@ -25,8 +25,8 @@ jobs:
       - name: Set up Go
         uses: actions/setup-go@v6
         with:
-          go-version: '1.24.1'
-          cache-dependency-path: ./src/WebApi/go.sum
+          go-version-file: src/WebApi/go.mod
+          cache-dependency-path: src/WebApi/go.sum
 
       - name: Build the application
         run: |
@@ -60,3 +60,4 @@ jobs:
           done
           echo "Healthcheck failed after 20 attempts."
           exit 1
+

--- a/.github/workflows/codeql.yml
+++ b/.github/workflows/codeql.yml
@@ -26,22 +26,22 @@ jobs:
       - name: Set up Go
         uses: actions/setup-go@v6
         with:
-          go-version: "1.24.1"
-          cache-dependency-path: ./src/WebApi/go.sum
+          go-version-file: src/WebApi/go.mod
+          cache-dependency-path: src/WebApi/go.sum
 
       - name: Initialize CodeQL
         uses: github/codeql-action/init@v4
         with:
           languages: go
+          build-mode: manual
           queries: security-and-quality
 
       - name: Build for CodeQL
         working-directory: ./src/WebApi
         run: go build -v ./...
-        env:
-          CODEQL_EXTRACTOR_GO_BUILD_TRACING: on
 
       - name: Perform CodeQL Analysis
         uses: github/codeql-action/analyze@v4
         with:
           category: "/language:go"
+

--- a/.github/workflows/main-release.yml
+++ b/.github/workflows/main-release.yml
@@ -1,6 +1,5 @@
 name: Main Release
 
-# Grant write permission for repository contents to allow pushing changes.
 permissions:
   contents: write
   packages: write
@@ -27,8 +26,8 @@ jobs:
       - name: Set up Go
         uses: actions/setup-go@v6
         with:
-          go-version: '1.24.1'
-          cache-dependency-path: ./src/WebApi/go.sum
+          go-version-file: src/WebApi/go.mod
+          cache-dependency-path: src/WebApi/go.sum
 
       - name: Build the application
         run: |
@@ -65,7 +64,7 @@ jobs:
           push: true
           tags: ghcr.io/jonathanperis/rinha2-back-end-go:latest
           platforms: linux/amd64,linux/arm64/v8
-          
+
   container-test:
     needs: build-push-image
     runs-on: ubuntu-latest
@@ -106,12 +105,8 @@ jobs:
 
       - name: Build and Run Docker Compose for Load Test
         run: |
-          docker compose -f ./prod/docker-compose.yml up k6 --build --force-recreate 
+          docker compose -f ./prod/docker-compose.yml up k6 --build --force-recreate
           sleep 10
-
-      # - name: Listing Files recursively
-      #   run: find . -printf '%y %p
-'
 
       - name: Upload Stress Test Report Artifact
         uses: actions/upload-artifact@v7
@@ -132,3 +127,4 @@ jobs:
           branch: gh-pages
           target-folder: reports
           clean: false
+


### PR DESCRIPTION
## Root cause
`go.mod` declares `go 1.25.0` but all three workflows installed Go `1.24.1`. CodeQL sets `GOTOOLCHAIN=local`, which prevents the toolchain from auto-upgrading — so `go build` exits 1 immediately, failing CodeQL, Main Release, and Build Check.

## Changes
- `codeql.yml`, `main-release.yml`, `build-check.yml`: replace `go-version: "1.24.1"` with `go-version-file: src/WebApi/go.mod` so the installed version always matches the module's requirement
- `codeql.yml`: add `build-mode: manual`