### PR TITLE
docs: update README and CLAUDE.md with correct badges, versions, and workflow

### DIFF
--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -97,3 +97,12 @@ rinha2-back-end-go/
 | Variable | Value |
 |----------|-------|
 | `DATABASE_URL` | `postgres://postgres:postgres@db:5432/rinha?sslmode=disable` |
+
+---
+
+## Contribution Workflow
+
+- **All changes** must go through a branch + PR strategy (never commit directly to main)
+- **PRs are rebase only** — no merge commits
+- **Repo-wide files** (SECURITY.md, CODE_OF_CONDUCT.md, CONTRIBUTING.md, FUNDING.yml, etc.) live in the `.github` repo — do not recreate them in this repository
+- **Use `gh` CLI** for all GitHub operations (repos, PRs, checks, merges, releases)

--- a/README.md
+++ b/README.md
@@ -1,20 +1,22 @@
 # rinha2-back-end-go
 
-> Go 1.23 implementation for the Rinha de Backend 2024/Q1 challenge with chi router, pgx driver, and PostgreSQL stored procedures
+> Go 1.25 implementation for the Rinha de Backend 2024/Q1 challenge with chi router, pgx driver, and PostgreSQL stored procedures
 
-[![CI](https://github.com/jonathanperis/rinha2-back-end-go/actions/workflows/build-check-webapi.yml/badge.svg)](https://github.com/jonathanperis/rinha2-back-end-go/actions/workflows/build-check-webapi.yml) [![License: MIT](https://img.shields.io/badge/License-MIT-yellow.svg)](LICENSE)
+[![Build Check](https://github.com/jonathanperis/rinha2-back-end-go/actions/workflows/build-check.yml/badge.svg)](https://github.com/jonathanperis/rinha2-back-end-go/actions/workflows/build-check.yml) [![Main Release](https://github.com/jonathanperis/rinha2-back-end-go/actions/workflows/main-release.yml/badge.svg)](https://github.com/jonathanperis/rinha2-back-end-go/actions/workflows/main-release.yml) [![CodeQL](https://github.com/jonathanperis/rinha2-back-end-go/actions/workflows/codeql.yml/badge.svg)](https://github.com/jonathanperis/rinha2-back-end-go/actions/workflows/codeql.yml) [![License: MIT](https://img.shields.io/badge/License-MIT-yellow.svg)](LICENSE)
+
+**[Live demo →](https://jonathanperis.github.io/rinha2-back-end-go/)** | **[Documentation →](https://jonathanperis.github.io/rinha2-back-end-go/docs/)**
 
 ---
 
 ## About
 
-A Go implementation of the Brazilian backend challenge Rinha de Backend 2024/Q1, where a fictional bank API must handle concurrent transactions under strict resource constraints (1.5 CPU, 550MB RAM total). Built as a minimal single-file API (~190 lines) using chi/v5 for routing and pgx/v5 for PostgreSQL access, with business logic in stored procedures. Built for learning purposes.
+A Go implementation of the Brazilian backend challenge Rinha de Backend 2024/Q1, where a fictional bank API must handle concurrent transactions under strict resource constraints (1.5 CPU, 550MB RAM total). Built as a minimal single-file API (~221 lines) using chi/v5 for routing and pgx/v5 for PostgreSQL access, with business logic in stored procedures. Built for learning purposes.
 
 ## Tech Stack
 
 | Technology | Version | Purpose |
 |-----------|---------|---------|
-| Go | 1.23 | API implementation |
+| Go | 1.25 | API implementation |
 | chi | v5 | HTTP router |
 | pgx | v5 | PostgreSQL driver with connection pool |
 | PostgreSQL | - | Database with stored procedures |
@@ -24,7 +26,7 @@ A Go implementation of the Brazilian backend challenge Rinha de Backend 2024/Q1,
 
 ## Features
 
-- Minimal single-file API implementation (~190 lines of Go)
+- Minimal single-file API implementation (~221 lines of Go)
 - Idiomatic Go with chi/v5 router and pgx/v5 driver
 - PostgreSQL stored procedures for server-side business logic
 - PostgreSQL tuned with synchronous_commit=0, fsync=0, full_page_writes=0
@@ -62,7 +64,11 @@ rinha2-back-end-go/
 
 ## CI/CD
 
-Two GitHub Actions workflows: `build-check-webapi.yml` runs on pull requests to build and health-check the API, and `main-release-webapi.yml` runs on the main branch to build a multi-platform Docker image and push it to GHCR.
+- **PR:** Go build + Docker health check (`build-check.yml`)
+- **Main:** Build + Multi-platform Docker push (amd64/arm64) to GHCR + k6 load test + GitHub Pages report (`main-release.yml`)
+- **Security:** CodeQL analysis on push, PRs, and weekly schedule (`codeql.yml`)
+- **Docs:** Auto-generated from wiki and deployed to GitHub Pages (`deploy-docs.yml`)
+- **Image:** `ghcr.io/jonathanperis/rinha2-back-end-go:latest`
 
 ## License
 


### PR DESCRIPTION
## Summary
- Fix Go version (1.23 → 1.25) and line count (~190 → ~221) in README
- Replace broken CI badge with correct Build Check, Main Release, CodeQL, and License badges
- Add **Live demo →** and **Documentation →** links
- Update CI/CD section with all 4 workflows and correct filenames
- Add Contribution Workflow section to CLAUDE.md (branch+PR strategy, rebase-only, gh CLI, repo-wide files in .github repo)

## Test plan
- [ ] Verify all 4 badges render correctly on the README
- [ ] Verify Live demo and Documentation links point to correct GitHub Pages URLs
- [ ] Verify Go version and line count match current codebase

🤖 Generated with [Claude Code](https://claude.com/claude-code)