### PR TITLE
fix: reverse postgres-exporter dependency direction

### DIFF
--- a/docker-compose.yml
+++ b/docker-compose.yml
@@ -32,8 +32,6 @@ services:
     image: postgres
     container_name: db-rinha
     restart: always
-    depends_on:
-      - postgres-exporter      
     volumes:
       - db-data:/var/lib/postgresql/data
       - ./docker-entrypoint-initdb.d:/docker-entrypoint-initdb.d
@@ -73,8 +71,11 @@ services:
           memory: "20MB"
 
   postgres-exporter:
-    image: prometheuscommunity/postgres-exporter 
+    image: prometheuscommunity/postgres-exporter
     container_name: postgres-exporter-rinha
+    depends_on:
+      db:
+        condition: service_healthy
     ports:
       - 9187:9187
     environment:


### PR DESCRIPTION
## Summary
- The `db` service incorrectly had `depends_on: postgres-exporter`, forcing the exporter to start before PostgreSQL
- This caused postgres-exporter to crash (can't connect to `db:5432`) and Docker Compose v2 to immediately mark `db` as unhealthy, failing the entire Build Check pipeline
- Reversed the dependency: removed `depends_on` from `db`, added `depends_on: db (service_healthy)` to `postgres-exporter`

## Test plan
- [ ] Build Check pipeline passes (has never passed before due to this bug)
- [ ] Verify `docker compose up nginx -d` starts all services correctly

🤖 Generated with [Claude Code](https://claude.com/claude-code)