### PR TITLE
ci: migrate GitHub Pages to actions deployment model

### DIFF
--- a/.github/workflows/deploy.yml
+++ b/.github/workflows/deploy.yml
@@ -1,18 +1,25 @@
-name: Deploy Docs
+name: Deploy to GitHub Pages
 
 on:
-  workflow_dispatch:
   push:
     branches: [main]
-    paths-ignore:
-      - 'docs/**'
-  gollum:
+  workflow_dispatch:
+
+permissions:
+  contents: write
+  pages: write
+  id-token: write
+
+concurrency:
+  group: github-pages
+  cancel-in-progress: false
 
 jobs:
   build-and-deploy:
     runs-on: ubuntu-latest
-    permissions:
-      contents: write
+    environment:
+      name: github-pages
+      url: ${{ steps.deployment.outputs.page_url }}
 
     steps:
       - uses: actions/checkout@v6
@@ -37,9 +44,21 @@ jobs:
           TEMPLATE_PATH: ".github/docs-template.html"
         run: node .github/generate-docs.js
 
-      - name: Commit and push docs
+      - name: Commit generated docs
         run: |
           git config user.name "github-actions[bot]"
           git config user.email "github-actions[bot]@users.noreply.github.com"
           git add docs/docs/index.html
           git diff --staged --quiet || (git commit -m "chore: regenerate docs from wiki [skip ci]" && git push)
+
+      - name: Configure Pages
+        uses: actions/configure-pages@v6
+
+      - name: Upload Pages artifact
+        uses: actions/upload-pages-artifact@v4
+        with:
+          path: docs/
+
+      - name: Deploy to GitHub Pages
+        id: deployment
+        uses: actions/deploy-pages@v5

--- a/.github/workflows/main-release.yml
+++ b/.github/workflows/main-release.yml
@@ -114,17 +114,13 @@ jobs:
           name: stress-test-report
           path: ./prod/conf/stress-test/reports/stress-test-report.html
 
-      - name: Prepare Report for GitHub Pages
+      - name: Commit Report to docs
         run: |
           TIMESTAMP=$(date +%Y%m%d%H%M%S)
-          mkdir -p gh-pages-reports
-          cp ./prod/conf/stress-test/reports/stress-test-report.html gh-pages-reports/stress-test-report-${TIMESTAMP}.html
-
-      - name: Deploy Report to GitHub Pages
-        uses: JamesIves/github-pages-deploy-action@v4
-        with:
-          folder: gh-pages-reports
-          branch: gh-pages
-          target-folder: reports
-          clean: false
+          mkdir -p docs/reports
+          cp ./prod/conf/stress-test/reports/stress-test-report.html docs/reports/stress-test-report-${TIMESTAMP}.html
+          git config user.name "github-actions[bot]"
+          git config user.email "github-actions[bot]@users.noreply.github.com"
+          git add docs/reports/
+          git diff --staged --quiet || (git commit -m "chore: add stress test report ${TIMESTAMP} [skip ci]" && git push)
 


### PR DESCRIPTION
## Summary
- Replace the old `pages-build-deployment` model with the new GitHub Actions deployment using `actions/configure-pages`, `actions/upload-pages-artifact`, and `actions/deploy-pages`
- Rename `deploy-docs.yml` → `deploy.yml` with the new deployment pipeline (generates docs + deploys `docs/` to Pages)
- Remove `JamesIves/github-pages-deploy-action` from `main-release.yml` — stress test reports are now committed to `docs/reports/` instead of pushed to a `gh-pages` branch

## Test plan
- [ ] Verify `deploy.yml` triggers on push to main and deploys to GitHub Pages successfully
- [ ] Verify `main-release.yml` commits stress test reports to `docs/reports/` correctly
- [ ] Confirm the old `pages-build-deployment` workflow is no longer active

🤖 Generated with [Claude Code](https://claude.com/claude-code)