### PR TITLE
ci: rewrite deploy.yml to match speedy-bird-lynx pattern

### DIFF
--- a/.github/workflows/deploy.yml
+++ b/.github/workflows/deploy.yml
@@ -6,59 +6,25 @@ on:
   workflow_dispatch:
 
 permissions:
-  contents: write
   pages: write
   id-token: write
+  contents: read
 
 concurrency:
   group: github-pages
   cancel-in-progress: false
 
 jobs:
-  build-and-deploy:
+  deploy:
     runs-on: ubuntu-latest
     environment:
       name: github-pages
       url: ${{ steps.deployment.outputs.page_url }}
-
     steps:
       - uses: actions/checkout@v6
-
-      - name: Clone wiki
-        run: git clone https://github.com/${{ github.repository }}.wiki.git wiki/ || echo "Wiki not found, skipping"
-
-      - name: Setup Node.js
-        uses: actions/setup-node@v6
-        with:
-          node-version: '20'
-
-      - name: Install marked
-        run: npm install marked --no-save
-
-      - name: Generate docs
-        env:
-          DOCS_TITLE: "rinha2-back-end-go"
-          DOCS_DESCRIPTION: "Go 1.23 implementation of Rinha de Backend 2024/Q1 — minimal single-file API built for performance under constraints"
-          GITHUB_URL: "https://github.com/jonathanperis/rinha2-back-end-go"
-          OUTPUT_PATH: "docs/docs/index.html"
-          TEMPLATE_PATH: ".github/docs-template.html"
-        run: node .github/generate-docs.js
-
-      - name: Commit generated docs
-        run: |
-          git config user.name "github-actions[bot]"
-          git config user.email "github-actions[bot]@users.noreply.github.com"
-          git add docs/docs/index.html
-          git diff --staged --quiet || (git commit -m "chore: regenerate docs from wiki [skip ci]" && git push)
-
-      - name: Configure Pages
-        uses: actions/configure-pages@v6
-
-      - name: Upload Pages artifact
-        uses: actions/upload-pages-artifact@v4
+      - uses: actions/configure-pages@v6
+      - uses: actions/upload-pages-artifact@v4
         with:
           path: docs/
-
-      - name: Deploy to GitHub Pages
-        id: deployment
+      - id: deployment
         uses: actions/deploy-pages@v5

--- a/.github/workflows/generate-docs.yml
+++ b/.github/workflows/generate-docs.yml
@@ -1,0 +1,41 @@
+name: Generate Docs
+
+on:
+  workflow_dispatch:
+  gollum:
+
+permissions:
+  contents: write
+
+jobs:
+  generate:
+    runs-on: ubuntu-latest
+    steps:
+      - uses: actions/checkout@v6
+
+      - name: Clone wiki
+        run: git clone https://github.com/${{ github.repository }}.wiki.git wiki/ || echo "Wiki not found, skipping"
+
+      - name: Setup Node.js
+        uses: actions/setup-node@v6
+        with:
+          node-version: '20'
+
+      - name: Install marked
+        run: npm install marked --no-save
+
+      - name: Generate docs
+        env:
+          DOCS_TITLE: "rinha2-back-end-go"
+          DOCS_DESCRIPTION: "Go 1.23 implementation of Rinha de Backend 2024/Q1 — minimal single-file API built for performance under constraints"
+          GITHUB_URL: "https://github.com/jonathanperis/rinha2-back-end-go"
+          OUTPUT_PATH: "docs/docs/index.html"
+          TEMPLATE_PATH: ".github/docs-template.html"
+        run: node .github/generate-docs.js
+
+      - name: Commit generated docs
+        run: |
+          git config user.name "github-actions[bot]"
+          git config user.email "github-actions[bot]@users.noreply.github.com"
+          git add docs/docs/index.html
+          git diff --staged --quiet || (git commit -m "chore: regenerate docs from wiki [skip ci]" && git push)

--- a/.github/workflows/main-release.yml
+++ b/.github/workflows/main-release.yml
@@ -114,13 +114,3 @@ jobs:
           name: stress-test-report
           path: ./prod/conf/stress-test/reports/stress-test-report.html
 
-      - name: Commit Report to docs
-        run: |
-          TIMESTAMP=$(date +%Y%m%d%H%M%S)
-          mkdir -p docs/reports
-          cp ./prod/conf/stress-test/reports/stress-test-report.html docs/reports/stress-test-report-${TIMESTAMP}.html
-          git config user.name "github-actions[bot]"
-          git config user.email "github-actions[bot]@users.noreply.github.com"
-          git add docs/reports/
-          git diff --staged --quiet || (git commit -m "chore: add stress test report ${TIMESTAMP} [skip ci]" && git push)
-


### PR DESCRIPTION
## Summary
- Rewrite `deploy.yml` to be an exact match of the [speedy-bird-lynx deployment pattern](https://github.com/jonathanperis/speedy-bird-lynx/blob/main/.github/workflows/deploy.yml) — clean, minimal: checkout → configure-pages → upload-pages-artifact → deploy-pages
- Extract doc generation (wiki clone, Node.js, marked, generate-docs.js) into its own `generate-docs.yml` workflow (triggers on wiki edits and manual dispatch)
- Remove report commit step from `main-release.yml` — stress test reports remain as downloadable artifacts

## Test plan
- [ ] Verify `deploy.yml` deploys `docs/` to GitHub Pages on push to main
- [ ] Verify `generate-docs.yml` generates and commits docs on wiki edit / manual trigger
- [ ] Verify `main-release.yml` uploads stress test report as artifact without committing to repo

🤖 Generated with [Claude Code](https://claude.com/claude-code)