### PR TITLE
docs: update docs page with current project info and analytics

### DIFF
--- a/docs/docs/index.html
+++ b/docs/docs/index.html
@@ -4,7 +4,7 @@
   <meta charset="UTF-8">
   <meta name="viewport" content="width=device-width, initial-scale=1.0">
   <title>rinha2-back-end-go - Documentation</title>
-  <meta name="description" content="Go 1.23 implementation of Rinha de Backend 2024/Q1 — minimal single-file API built for performance under constraints">
+  <meta name="description" content="Go 1.25 implementation of Rinha de Backend 2024/Q1 — minimal single-file API built for performance under constraints">
   <link href="https://fonts.googleapis.com/css2?family=Fira+Code:wght@300;400;600;700&display=swap" rel="stylesheet">
   <style>
     :root {
@@ -380,6 +380,13 @@
     }
   </style>
   <script src="https://cdn.jsdelivr.net/npm/marked/marked.min.js"></script>
+  <script async src="https://www.googletagmanager.com/gtag/js?id=G-0D89HNSJP8"></script>
+  <script>
+    window.dataLayer = window.dataLayer || [];
+    function gtag(){dataLayer.push(arguments);}
+    gtag('js', new Date());
+    gtag('config', 'G-0D89HNSJP8');
+  </script>
 </head>
 <body>
 
@@ -399,7 +406,7 @@
   <aside class="sidebar" id="sidebar">
     <div class="sidebar-header">
       <h1 class="repo-title">rinha2-back-end-go</h1>
-      <p class="repo-description">Go 1.23 implementation of Rinha de Backend 2024/Q1 — minimal single-file API built for performance under constraints</p>
+      <p class="repo-description">Go 1.25 implementation of Rinha de Backend 2024/Q1 — minimal single-file API built for performance under constraints</p>
       <input type="text" id="searchInput" class="search-box" placeholder="Search documentation...">
     </div>
     <div class="sidebar-nav-container">
@@ -425,8 +432,7 @@
       
 <section id="home" class="doc-section">
   <h1 class="page-title">Home</h1>
-  <h1>rinha2-back-end-go</h1>
-<p>Go 1.23 implementation for the Rinha de Backend 2024/Q1 challenge. Manages a fictional bank API with transaction processing and balance statements under strict resource constraints (1.5 CPU, 550MB RAM total across all containers).</p>
+<p>Go 1.25 implementation for the Rinha de Backend 2024/Q1 challenge. Manages a fictional bank API with transaction processing and balance statements under strict resource constraints (1.5 CPU, 550MB RAM total across all containers).</p>
 <h2>Wiki Pages</h2>
 <table>
 <thead>
@@ -458,7 +464,7 @@
 </tbody></table>
 <h2>Key Features</h2>
 <ul>
-<li>Minimal single-file API implementation (~190 lines of Go)</li>
+<li>Minimal single-file API implementation (~221 lines of Go)</li>
 <li>chi/v5 router with pgx/v5 PostgreSQL driver</li>
 <li>PostgreSQL stored procedures for server-side business logic</li>
 <li>All requests under 800ms at 250MB RAM usage</li>
@@ -470,7 +476,6 @@
 
 <section id="architecture" class="doc-section">
   <h1 class="page-title">Architecture</h1>
-  <h1>Architecture</h1>
 <h2>Overview</h2>
 <p>The system follows a shared architecture across all Rinha de Backend implementations: two API instances behind an Nginx reverse proxy, with a single PostgreSQL database and an observability stack.</p>
 <h2>Services</h2>
@@ -485,13 +490,13 @@
 </thead>
 <tbody><tr>
 <td>webapi1</td>
-<td>Go 1.23 API instance (chi/v5 + pgx/v5)</td>
+<td>Go 1.25 API instance (chi/v5 + pgx/v5)</td>
 <td>0.4</td>
 <td>100MB</td>
 </tr>
 <tr>
 <td>webapi2</td>
-<td>Go 1.23 API instance (chi/v5 + pgx/v5)</td>
+<td>Go 1.25 API instance (chi/v5 + pgx/v5)</td>
 <td>0.4</td>
 <td>100MB</td>
 </tr>
@@ -531,7 +536,7 @@
 </ul>
 <h2>Implementation Details</h2>
 <ul>
-<li>Minimal single-file Go API (~190 lines)</li>
+<li>Minimal single-file Go API (~221 lines)</li>
 <li>chi/v5 lightweight HTTP router</li>
 <li>pgx/v5 PostgreSQL driver with built-in connection pooling</li>
 <li>Multi-stage Docker build for minimal container image size</li>
@@ -541,7 +546,6 @@
 
 <section id="challenge" class="doc-section">
   <h1 class="page-title">Challenge</h1>
-  <h1>Challenge</h1>
 <h2>Rinha de Backend 2024/Q1</h2>
 <p>The Rinha de Backend is a Brazilian backend programming challenge. The 2024/Q1 edition simulates a fictional bank called &quot;Rinha Financeira&quot; that manages up to 5 named clients, each seeded at startup with a credit limit and initial balance.</p>
 <h2>Endpoints</h2>
@@ -579,27 +583,37 @@
 
 <section id="ci-cd-pipeline" class="doc-section">
   <h1 class="page-title">CI CD Pipeline</h1>
-  <h1>CI/CD Pipeline</h1>
 <h2>Workflows</h2>
-<p>This repository uses two GitHub Actions workflows:</p>
-<h3>build-check-webapi.yml</h3>
+<p>This repository uses four GitHub Actions workflows:</p>
+<h3>build-check.yml</h3>
 <ul>
 <li><strong>Trigger:</strong> Pull requests</li>
-<li><strong>Steps:</strong> Builds the API container and runs a health check to verify the service starts correctly</li>
+<li><strong>Steps:</strong> Builds the Go application and runs a Docker Compose health check to verify the service starts correctly</li>
 <li><strong>Purpose:</strong> Catch build failures and regressions before merging</li>
 </ul>
-<h3>main-release-webapi.yml</h3>
+<h3>main-release.yml</h3>
 <ul>
 <li><strong>Trigger:</strong> Push to main branch</li>
-<li><strong>Steps:</strong> Builds a multi-platform Docker image and pushes it to GitHub Container Registry (GHCR)</li>
-<li><strong>Purpose:</strong> Automated release of production-ready container images</li>
+<li><strong>Steps:</strong> Builds the Go application, creates a multi-platform Docker image (amd64/arm64), pushes to GitHub Container Registry (GHCR), runs container health check, and executes k6 load tests</li>
+<li><strong>Purpose:</strong> Automated release of production-ready container images with stress test validation</li>
+</ul>
+<h3>codeql.yml</h3>
+<ul>
+<li><strong>Trigger:</strong> Push to main, pull requests, and weekly schedule</li>
+<li><strong>Steps:</strong> Runs CodeQL security analysis on Go code</li>
+<li><strong>Purpose:</strong> Detect security vulnerabilities and code quality issues</li>
+</ul>
+<h3>deploy.yml</h3>
+<ul>
+<li><strong>Trigger:</strong> Push to main branch</li>
+<li><strong>Steps:</strong> Deploys the <code>docs/</code> directory to GitHub Pages using the GitHub Actions deployment model</li>
+<li><strong>Purpose:</strong> Publish project documentation and landing page</li>
 </ul>
 
 </section>
 
 <section id="getting-started" class="doc-section">
   <h1 class="page-title">Getting Started</h1>
-  <h1>Getting Started</h1>
 <h2>Prerequisites</h2>
 <ul>
 <li>Docker with Docker Compose</li>
@@ -645,7 +659,6 @@ docker compose up nginx -d --build
 
 <section id="performance" class="doc-section">
   <h1 class="page-title">Performance</h1>
-  <h1>Performance</h1>
 <h2>Resource Constraints</h2>
 <p>The challenge allows a total of 1.5 CPU and 550MB RAM across all containers.</p>
 <h2>Actual Usage</h2>


### PR DESCRIPTION
## Summary
- Update Go version references from 1.23 to **1.25** (matches go.mod)
- Update line count from ~190 to **~221** (actual main.go)
- Fix CI/CD section: correct workflow filenames (`build-check.yml`, `main-release.yml`) and add missing workflows (`codeql.yml`, `deploy.yml`)
- Remove **duplicate h1 titles** in every section (Home, Architecture, Challenge, CI/CD, Getting Started, Performance)
- Add **Google Analytics** tag to `docs/docs/index.html` (matching `docs/index.html`)

Wiki pages (Home, Architecture, CI-CD-Pipeline) were also updated with the same corrections directly.

## Test plan
- [ ] Verify `docs/docs/index.html` renders correctly with no duplicate headings
- [ ] Verify Google Analytics tag is present in docs page source
- [ ] Confirm wiki pages reflect updated Go version and workflow names

🤖 Generated with [Claude Code](https://claude.com/claude-code)