### PR TITLE
fix: resolve build-check postgres crash and CI fragility

### DIFF
--- a/.github/workflows/build-check.yml
+++ b/.github/workflows/build-check.yml
@@ -42,22 +42,19 @@ jobs:
           fetch-depth: 0
 
       - name: Build and Run Docker Compose for Healthcheck Test
-        run: |
-          docker compose -f ./docker-compose.yml up nginx -d
-          sleep 10
+        run: docker compose -f ./docker-compose.yml up nginx --wait
+
+      - name: Dump container logs on failure
+        if: failure()
+        run: docker compose -f ./docker-compose.yml logs db
 
       - name: Test Healthcheck Endpoint
         run: |
-          for i in {1..20}; do
-            STATUS=$(curl -s -o /dev/null -w "%{http_code}" http://localhost:9999/healthz)
-            if [ "$STATUS" -eq 200 ]; then
-              echo "Healthcheck passed with status $STATUS"
-              exit 0
-            else
-              echo "Healthcheck attempt $i failed with status $STATUS. Retrying..."
-              sleep 2
-            fi
-          done
-          echo "Healthcheck failed after 20 attempts."
-          exit 1
+          STATUS=$(curl -s -o /dev/null -w "%{http_code}" http://localhost:9999/healthz)
+          if [ "$STATUS" -eq 200 ]; then
+            echo "Healthcheck passed with status $STATUS"
+          else
+            echo "Healthcheck failed with status $STATUS"
+            exit 1
+          fi
 

--- a/docker-compose.yml
+++ b/docker-compose.yml
@@ -29,7 +29,7 @@ services:
       - "4201:8080"
 
   db:
-    image: postgres
+    image: postgres:16
     container_name: db-rinha
     restart: always
     volumes:

--- a/docker-entrypoint-initdb.d/rinha.dump.sql
+++ b/docker-entrypoint-initdb.d/rinha.dump.sql
@@ -47,8 +47,8 @@ COPY public."Transacoes" ("Id", "Valor", "ClienteId", "Tipo", "Descricao", "Real
 \.
 
 -- Critical fix for sequences
-SELECT pg_catalog.setval('public."Clientes_Id_seq"', (SELECT MAX("Id") FROM public."Clientes"), true);
-SELECT pg_catalog.setval('public."Transacoes_Id_seq"', (SELECT MAX("Id") FROM public."Transacoes"), true);
+SELECT pg_catalog.setval('public."Clientes_Id_seq"', COALESCE((SELECT MAX("Id") FROM public."Clientes"), 1), true);
+SELECT pg_catalog.setval('public."Transacoes_Id_seq"', COALESCE((SELECT MAX("Id") FROM public."Transacoes"), 1), true);
 
 ALTER TABLE ONLY public."Clientes"
     ADD CONSTRAINT "PK_Clientes" PRIMARY KEY ("Id");


### PR DESCRIPTION
## Summary

- **Pin `postgres:16`** in `docker-compose.yml` — `image: postgres` (untagged) silently pulls any new major release, which can break initialization at any time
- **Fix NULL `setval` in `rinha.dump.sql`** — `MAX("Id")` on an empty `Transacoes` table returns NULL; passing NULL to `setval` crashes the postgres init script, making the container exit within 500ms and fail `depends_on: service_healthy` before any healthcheck probe fires
- **Replace `docker compose up -d` + `sleep 10` with `--wait`** — blocks until all healthchecks pass natively; removes the arbitrary timer and the fragile 20-retry curl loop
- **Add diagnostic log dump on failure** — `docker compose logs db` now runs automatically (`if: failure()`) so future crashes show the actual postgres error in CI output

## Test plan

- [ ] Verify `container-test` job passes on this PR
- [ ] Confirm "Dump container logs on failure" step is skipped on success
- [ ] Confirm `setup-build-test` (go build) continues to pass unchanged

🤖 Generated with [Claude Code](https://claude.com/claude-code)