### PR TITLE
ci: split multi-arch build to unblock pipeline from arm64

### DIFF
--- a/.github/workflows/main-release.yml
+++ b/.github/workflows/main-release.yml
@@ -10,6 +10,9 @@ on:
       - main
   workflow_dispatch:
 
+env:
+  IMAGE: ghcr.io/jonathanperis/rinha2-back-end-go
+
 jobs:
   setup-build-test:
     runs-on: ubuntu-latest
@@ -33,9 +36,11 @@ jobs:
         run: |
           go build -o rinha2-back-end-go .
 
-  build-push-image:
+  build-push-amd64:
     needs: setup-build-test
     runs-on: ubuntu-latest
+    outputs:
+      digest: ${{ steps.build.outputs.digest }}
 
     steps:
       - name: Checkout Repository
@@ -56,17 +61,53 @@ jobs:
           username: ${{ github.actor }}
           password: ${{ secrets.GITHUB_TOKEN }}
 
-      - name: Build and Push Docker Image
+      - name: Build and Push Docker Image (amd64)
+        id: build
         uses: docker/build-push-action@v7
         with:
           context: ./src/WebApi
           file: ./src/WebApi/Dockerfile
           push: true
-          tags: ghcr.io/jonathanperis/rinha2-back-end-go:latest
-          platforms: linux/amd64,linux/arm64/v8
+          tags: ${{ env.IMAGE }}:latest
+          platforms: linux/amd64
+
+  build-push-arm64:
+    needs: build-push-amd64
+    runs-on: ubuntu-latest
+    outputs:
+      digest: ${{ steps.build.outputs.digest }}
+
+    steps:
+      - name: Checkout Repository
+        uses: actions/checkout@v6
+        with:
+          fetch-depth: 0
+
+      - name: Set up QEMU
+        uses: docker/setup-qemu-action@v4
+
+      - name: Set up Docker Buildx
+        uses: docker/setup-buildx-action@v4
+
+      - name: Login to GitHub Container Registry
+        uses: docker/login-action@v4
+        with:
+          registry: ghcr.io
+          username: ${{ github.actor }}
+          password: ${{ secrets.GITHUB_TOKEN }}
+
+      - name: Build and Push Docker Image (arm64)
+        id: build
+        uses: docker/build-push-action@v7
+        with:
+          context: ./src/WebApi
+          file: ./src/WebApi/Dockerfile
+          push: true
+          tags: ${{ env.IMAGE }}:latest-arm64
+          platforms: linux/arm64/v8
 
   container-test:
-    needs: build-push-image
+    needs: build-push-amd64
     runs-on: ubuntu-latest
     steps:
       - name: Checkout Repository
@@ -94,6 +135,24 @@ jobs:
           echo "Healthcheck failed after 20 attempts."
           exit 1
 
+  merge-manifest:
+    needs: [build-push-amd64, build-push-arm64]
+    runs-on: ubuntu-latest
+    steps:
+      - name: Login to GitHub Container Registry
+        uses: docker/login-action@v4
+        with:
+          registry: ghcr.io
+          username: ${{ github.actor }}
+          password: ${{ secrets.GITHUB_TOKEN }}
+
+      - name: Merge into multi-arch manifest
+        run: |
+          docker buildx imagetools create \
+            --tag ${{ env.IMAGE }}:latest \
+            ${{ env.IMAGE }}@${{ needs.build-push-amd64.outputs.digest }} \
+            ${{ env.IMAGE }}@${{ needs.build-push-arm64.outputs.digest }}
+
   load-test:
     runs-on: ubuntu-latest
     needs: container-test
@@ -113,4 +172,3 @@ jobs:
         with:
           name: stress-test-report
           path: ./prod/conf/stress-test/reports/stress-test-report.html
-


### PR DESCRIPTION
## Summary

- Replaces the single `build-push-image` job (amd64 + arm64 in one step) with three focused jobs
- `build-push-amd64` — builds `linux/amd64`, pushes as `:latest`, outputs digest
- `build-push-arm64` — builds `linux/arm64/v8`, pushes as `:latest-arm64`, outputs digest; starts after amd64
- `merge-manifest` — merges both digests into `:latest` multi-arch OCI manifest; needs both build jobs
- `container-test` now depends on `build-push-amd64` and runs in parallel with `build-push-arm64`, unblocking the pipeline from slow arm64 emulation
- Adds top-level `IMAGE` env var for DRY tag references

## Test plan

- [ ] Verify `build-push-amd64` pushes `ghcr.io/jonathanperis/rinha2-back-end-go:latest` (amd64 only)
- [ ] Verify `build-push-arm64` pushes `ghcr.io/jonathanperis/rinha2-back-end-go:latest-arm64`
- [ ] Verify `merge-manifest` produces a multi-arch `:latest` manifest covering both digests
- [ ] Verify `container-test` and `build-push-arm64` run in parallel after `build-push-amd64`
- [ ] Verify `load-test` still runs after `container-test`

🤖 Generated with [Claude Code](https://claude.com/claude-code)