### PR TITLE
docs: add full SEO metadata to GitHub Pages site

### DIFF
--- a/docs/index.html
+++ b/docs/index.html
@@ -4,6 +4,44 @@
     <meta charset="UTF-8">
     <meta name="viewport" content="width=device-width, initial-scale=1.0">
     <title>rinha2-back-end-go | High Speed Performance</title>
+    <meta name="description" content="High-performance banking API for the Rinha de Backend challenge. Built with Go, chi router, and pgx. 221 lines under strict resource constraints (1.5 CPU, 550MB RAM).">
+    <meta name="keywords" content="Go, Golang, chi, pgx, PostgreSQL, banking API, Rinha de Backend, performance, concurrent, minimal API">
+    <link rel="canonical" href="https://jonathanperis.github.io/rinha2-back-end-go/">
+    <meta name="theme-color" content="#00ADD8">
+
+    <!-- Open Graph -->
+    <meta property="og:type" content="website">
+    <meta property="og:title" content="rinha2-back-end-go | High Speed Performance">
+    <meta property="og:description" content="High-performance banking API for the Rinha de Backend challenge. Built with Go, chi router, and pgx. 221 lines under strict resource constraints.">
+    <meta property="og:url" content="https://jonathanperis.github.io/rinha2-back-end-go/">
+    <meta property="og:site_name" content="rinha2-back-end-go">
+    <meta property="og:locale" content="en_US">
+
+    <!-- Twitter Card -->
+    <meta name="twitter:card" content="summary_large_image">
+    <meta name="twitter:title" content="rinha2-back-end-go | High Speed Performance">
+    <meta name="twitter:description" content="High-performance banking API for the Rinha de Backend challenge. Built with Go, chi router, and pgx. 221 lines.">
+    <meta name="twitter:creator" content="@jperis_silva">
+
+    <!-- JSON-LD Structured Data -->
+    <script type="application/ld+json">
+    {
+      "@context": "https://schema.org",
+      "@type": "SoftwareSourceCode",
+      "name": "Rinha de Backend — Go",
+      "description": "High-performance banking API for the Rinha de Backend challenge. Built with Go, chi router, and pgx. 221 lines under strict resource constraints (1.5 CPU, 550MB RAM).",
+      "url": "https://jonathanperis.github.io/rinha2-back-end-go/",
+      "codeRepository": "https://github.com/jonathanperis/rinha2-back-end-go",
+      "programmingLanguage": "Go",
+      "license": "https://github.com/jonathanperis/rinha2-back-end-go/blob/main/LICENSE",
+      "author": {
+        "@type": "Person",
+        "name": "Jonathan Peris",
+        "url": "https://jonathanperis.github.io/"
+      }
+    }
+    </script>
+
     <style>
         @import url('https://fonts.googleapis.com/css2?family=Fira+Code:wght@300;400;600;700&display=swap');
         

--- a/docs/robots.txt
+++ b/docs/robots.txt
@@ -1,0 +1,4 @@
+User-agent: *
+Allow: /
+
+Sitemap: https://jonathanperis.github.io/rinha2-back-end-go/sitemap.xml

--- a/docs/sitemap.xml
+++ b/docs/sitemap.xml
@@ -1,0 +1,9 @@
+<?xml version="1.0" encoding="UTF-8"?>
+<urlset xmlns="http://www.sitemaps.org/schemas/sitemap/0.9">
+  <url>
+    <loc>https://jonathanperis.github.io/rinha2-back-end-go/</loc>
+    <lastmod>2026-04-04</lastmod>
+    <changefreq>monthly</changefreq>
+    <priority>1.0</priority>
+  </url>
+</urlset>


### PR DESCRIPTION
## Summary
- Add `meta description`, `keywords`, `canonical`, `theme-color` to `docs/index.html`
- Add Open Graph and Twitter Card tags for social previews
- Add JSON-LD `SoftwareSourceCode` structured data for rich search results
- Create `docs/robots.txt` and `docs/sitemap.xml`

## Test plan
- [ ] Verify page renders correctly at https://jonathanperis.github.io/rinha2-back-end-go/
- [ ] Check OG tags with https://opengraph.io or Twitter Card Validator

🤖 Generated with [Claude Code](https://claude.com/claude-code)