### PR TITLE
refactor: standardize Google Analytics component

### DIFF
--- a/docs/src/components/Analytics.astro
+++ b/docs/src/components/Analytics.astro
@@ -1,0 +1,18 @@
+---
+const GA_ID = import.meta.env.PUBLIC_GA_ID;
+---
+
+{GA_ID && (
+  <>
+    <script
+      async
+      src={`https://www.googletagmanager.com/gtag/js?id=${GA_ID}`}
+    ></script>
+    <script define:vars={{ GA_ID }}>
+      window.dataLayer = window.dataLayer || [];
+      function gtag() { dataLayer.push(arguments); }
+      gtag('js', new Date());
+      gtag('config', GA_ID);
+    </script>
+  </>
+)}

--- a/docs/src/layouts/BaseLayout.astro
+++ b/docs/src/layouts/BaseLayout.astro
@@ -1,5 +1,6 @@
 ---
 import '../styles/globals.css';
+import Analytics from '../components/Analytics.astro';
 
 interface Props {
   title?: string;
@@ -10,8 +11,6 @@ const {
   title = 'rinha2-back-end-go | Less is More. Except Error Handling.',
   description = 'High-performance banking API for the Rinha de Backend challenge. Built with Go 1.25, chi/v5 router, and pgx/v5 connection pool. 221 lines under strict resource constraints (1.5 CPU, 550MB RAM).'
 } = Astro.props;
-
-const GA_ID = import.meta.env.PUBLIC_GA_ID;
 
 const jsonLd = {
   '@context': 'https://schema.org',
@@ -62,17 +61,9 @@ const jsonLd = {
     <script type="application/ld+json" set:html={JSON.stringify(jsonLd)} />
 
     <title>{title}</title>
+    <Analytics />
   </head>
   <body>
-    <!-- Google Analytics -->
-    <script is:inline async src={`https://www.googletagmanager.com/gtag/js?id=${GA_ID}`}></script>
-    <script is:inline define:vars={{ GA_ID }}>
-      window.dataLayer = window.dataLayer || [];
-      function gtag() { dataLayer.push(arguments); }
-      gtag('js', new Date());
-      gtag('config', GA_ID);
-    </script>
-
     <div class="particles">
       <div class="particle"></div>
       <div class="particle"></div>


### PR DESCRIPTION
## Summary

This PR standardizes the Google Analytics implementation to match the pattern used in `jonathanperis.github.io` and `grande-livro-maconaria`.

### Changes
- Create `docs/src/components/Analytics.astro` with GA_ID environment variable
- Remove inline GA code from `BaseLayout.astro`
- Add conditional rendering `{GA_ID && (...)}` pattern
- Import Analytics component in BaseLayout

### Benefits
- Clean separation of concerns
- Conditional rendering prevents errors when GA_ID is missing
- Easier to maintain and consistent across all GH Pages repos
- Reusable component pattern