### PR TITLE
ci: skip Go build/CodeQL on docs-only PRs

### DIFF
--- a/.github/workflows/build-check.yml
+++ b/.github/workflows/build-check.yml
@@ -10,7 +10,27 @@ on:
   workflow_dispatch:
 
 jobs:
+  filter:
+    runs-on: ubuntu-latest
+    outputs:
+      relevant: ${{ steps.changes.outputs.src }}
+    steps:
+      - name: Detect relevant changes
+        uses: dorny/paths-filter@v3
+        id: changes
+        with:
+          filters: |
+            src:
+              - 'src/**'
+              - 'go.mod'
+              - 'go.sum'
+              - 'Dockerfile*'
+              - 'docker-compose*.yml'
+              - '.github/workflows/build-check.yml'
+
   setup-build-test:
+    needs: filter
+    if: github.event_name != 'pull_request' || needs.filter.outputs.relevant == 'true'
     runs-on: ubuntu-latest
     defaults:
       run:
@@ -33,7 +53,8 @@ jobs:
           go build -o rinha2-back-end-go .
 
   container-test:
-    needs: setup-build-test
+    needs: [filter, setup-build-test]
+    if: github.event_name != 'pull_request' || needs.filter.outputs.relevant == 'true'
     runs-on: ubuntu-latest
     steps:
       - name: Checkout Repository
@@ -57,4 +78,3 @@ jobs:
             echo "Healthcheck failed with status $STATUS"
             exit 1
           fi
-

--- a/.github/workflows/codeql.yml
+++ b/.github/workflows/codeql.yml
@@ -13,8 +13,26 @@ permissions:
   security-events: write
 
 jobs:
+  filter:
+    runs-on: ubuntu-latest
+    outputs:
+      relevant: ${{ steps.changes.outputs.src }}
+    steps:
+      - name: Detect relevant changes
+        uses: dorny/paths-filter@v3
+        id: changes
+        with:
+          filters: |
+            src:
+              - 'src/**'
+              - 'go.mod'
+              - 'go.sum'
+              - '.github/workflows/codeql.yml'
+
   analyze:
     name: Analyze (go)
+    needs: filter
+    if: github.event_name != 'pull_request' || needs.filter.outputs.relevant == 'true'
     runs-on: ubuntu-latest
 
     steps:
@@ -44,4 +62,3 @@ jobs:
         uses: github/codeql-action/analyze@v4
         with:
           category: "/language:go"
-


### PR DESCRIPTION
## Summary
- Adds a `filter` job (using [`dorny/paths-filter@v3`](https://github.com/dorny/paths-filter)) to both `build-check.yml` and `codeql.yml`
- Downstream jobs (`setup-build-test`, `container-test`, `analyze`) skip when a PR touches no relevant files
- Push to `main` and the weekly CodeQL schedule are **unaffected** — the `if` short-circuits to true on non-PR events

## Why
Dependabot PR #38 (postcss in `/docs`) failed Go CI even though the change is npm/docs-only. The Go check failed on a stale `go.sum` issue from old pgx 5.7.0. PR #37 fixed that on main, but the underlying problem — heavy Go CI running on docs-only changes — remains. This PR fixes that.

## Behaviour
| PR touches | `setup-build-test` / `container-test` / `Analyze (go)` |
|------------|--------------------------------------------------------|
| `src/**` or go.mod/go.sum or Dockerfile | runs as before |
| docs-only / README-only / CODEOWNERS-only | skipped (= success for required checks) |
| this workflow file | runs (workflow self-test) |

## Test plan
- [ ] CI on this PR runs and passes (workflow files are in the path filter)
- [ ] After merge, open a docs-only PR and confirm Go checks resolve as skipped
- [ ] Confirm `main` push still triggers full Go CI

🤖 Generated with [Claude Code](https://claude.com/claude-code)