### PR TITLE
ci: delegate Deploy to reusable workflow in .github

### DIFF
--- a/.github/workflows/deploy.yml
+++ b/.github/workflows/deploy.yml
@@ -10,38 +10,9 @@ permissions:
   id-token: write
   contents: read
 
-concurrency:
-  group: github-pages
-  cancel-in-progress: false
-
 jobs:
   deploy:
-    runs-on: ubuntu-latest
-    environment:
-      name: github-pages
-      url: ${{ steps.deployment.outputs.page_url }}
-    steps:
-      - uses: actions/checkout@v6
-
-      - uses: actions/setup-node@v6
-        with:
-          node-version: '22'
-          cache: 'npm'
-          cache-dependency-path: docs/package-lock.json
-
-      - name: Install dependencies
-        run: npm ci
-        working-directory: docs
-
-      - name: Build
-        run: npm run build
-        working-directory: docs
-        env:
-          PUBLIC_GA_ID: ${{ secrets.PUBLIC_GA_ID }}
-
-      - uses: actions/upload-pages-artifact@v5
-        with:
-          path: docs/out/
-
-      - id: deployment
-        uses: actions/deploy-pages@v5
+    uses: jonathanperis/.github/.github/workflows/pages-docs-deploy.yml@main
+    secrets: inherit
+    with:
+      package-manager: npm


### PR DESCRIPTION
## Summary
Delegates this repo's `Deploy to GitHub Pages` workflow to the reusable workflow added in [jonathanperis/.github#3](https://github.com/jonathanperis/.github/pull/3).

## Before / After
- Before: ~30 lines of deploy boilerplate, byte-identical across 5 sibling rinha2-back-end-* repos
- After: ~10 lines that call `jonathanperis/.github/.github/workflows/pages-docs-deploy.yml@main`

## Why
Future fixes (action version bumps, security patches, performance tweaks) land **once** in `.github` and propagate to all consumer repos. No more drift across the polyglot family.

## Notes
- `package-manager: npm` preserved for now — bun migration is a separate concern
- `secrets: inherit` so `PUBLIC_GA_ID` continues to flow through

🤖 Generated with [Claude Code](https://claude.com/claude-code)