### PR TITLE
docs: migrate wiki content to wiki/ folder

### DIFF
--- a/wiki/Architecture.md
+++ b/wiki/Architecture.md
@@ -1,0 +1,35 @@
+# Architecture
+
+## Overview
+
+The system follows a shared architecture across all Rinha de Backend implementations: two API instances behind an Nginx reverse proxy, with a single PostgreSQL database and an observability stack.
+
+## Services
+
+| Service | Role | CPU | RAM |
+|---------|------|-----|-----|
+| webapi1 | Go 1.25 API instance (chi/v5 + pgx/v5) | 0.4 | 100MB |
+| webapi2 | Go 1.25 API instance (chi/v5 + pgx/v5) | 0.4 | 100MB |
+| nginx | Reverse proxy / load balancer (least-conn) | 0.2 | 20MB |
+| postgresql | Database with stored procedures | 0.5 | 330MB |
+| k6 | Load testing | (not counted) | (not counted) |
+| grafana + influxdb | Observability dashboards | (not counted) | (not counted) |
+
+## Load Balancing
+
+Nginx uses `least_conn` strategy to distribute requests across the two API instances.
+
+## Database
+
+Business logic is implemented in PostgreSQL stored procedures. The database is tuned for maximum write performance:
+
+- `synchronous_commit=0` — no wait for WAL flush
+- `fsync=0` — skip fsync on writes
+- `full_page_writes=0` — skip full page writes
+
+## Implementation Details
+
+- Minimal single-file Go API (~221 lines)
+- chi/v5 lightweight HTTP router
+- pgx/v5 PostgreSQL driver with built-in connection pooling
+- Multi-stage Docker build for minimal container image size

--- a/wiki/CI-CD-Pipeline.md
+++ b/wiki/CI-CD-Pipeline.md
@@ -1,0 +1,29 @@
+# CI/CD Pipeline
+
+## Workflows
+
+This repository uses four GitHub Actions workflows:
+
+### build-check.yml
+
+- **Trigger:** Pull requests
+- **Steps:** Builds the Go application and runs a Docker Compose health check to verify the service starts correctly
+- **Purpose:** Catch build failures and regressions before merging
+
+### main-release.yml
+
+- **Trigger:** Push to main branch
+- **Steps:** Builds the Go application, creates a multi-platform Docker image (amd64/arm64), pushes to GitHub Container Registry (GHCR), runs container health check, and executes k6 load tests
+- **Purpose:** Automated release of production-ready container images with stress test validation
+
+### codeql.yml
+
+- **Trigger:** Push to main, pull requests, and weekly schedule
+- **Steps:** Runs CodeQL security analysis on Go code
+- **Purpose:** Detect security vulnerabilities and code quality issues
+
+### deploy.yml
+
+- **Trigger:** Push to main branch
+- **Steps:** Deploys the `docs/` directory to GitHub Pages using the GitHub Actions deployment model
+- **Purpose:** Publish project documentation and landing page

--- a/wiki/Challenge.md
+++ b/wiki/Challenge.md
@@ -1,0 +1,26 @@
+# Challenge
+
+## Rinha de Backend 2024/Q1
+
+The Rinha de Backend is a Brazilian backend programming challenge. The 2024/Q1 edition simulates a fictional bank called "Rinha Financeira" that manages up to 5 named clients, each seeded at startup with a credit limit and initial balance.
+
+## Endpoints
+
+Two API endpoints are required:
+
+| Endpoint | Method | Description |
+|----------|--------|-------------|
+| `/clientes/{id}/transacoes` | POST | Submit a debit or credit transaction for a client (IDs 1-5) |
+| `/clientes/{id}/extrato` | GET | Get a client's current balance, credit limit, and recent transactions |
+
+## Constraints
+
+The challenge imposes strict resource limits across all containers combined:
+
+- **1.5 CPU total** shared across all services
+- **550MB RAM total** shared across all services
+- The system is stress tested using Grafana k6 with concurrent users submitting transactions and querying statements
+
+## Source
+
+Full specification: [github.com/zanfranceschi/rinha-de-backend-2024-q1L(https://github.com/zanfranceschi/rinha-de-backend-2024-q1.md)

--- a/wiki/Getting-Started.md
+++ b/wiki/Getting-Started.md
@@ -1,0 +1,40 @@
+# Getting Started
+
+## Prerequisites
+
+- Docker with Docker Compose
+
+## Clone and Run
+
+```bash
+git clone https://github.com/jonathanperis/rinha2-back-end-go.git
+cd rinha2-back-end-go
+docker compose up nginx -d --build
+```
+
+## Access
+
+The API is available at `http://localhost:9999`
+
+## Endpoints
+
+| Endpoint | Method | Description |
+|----------|--------|-------------|
+| `/clientes/{id}/transacoes` | POST | Submit debit or credit transaction |
+| `/clientes/{id}/extrato` | GET | Get account balance statement |
+
+## Example Requests
+
+### Create Transaction
+
+```bash
+curl -X POST http://localhost:9999/clientes/1/transacoes \
+  -H "Content-Type: application/json" \
+  -d '{"valor": 1000, "tipo": "c", "descricao": "deposito"}'
+```
+
+### Get Statement
+
+```bash
+curl http://localhost:9999/clientes/1/extrato
+```

--- a/wiki/Performance.md
+++ b/wiki/Performance.md
@@ -1,0 +1,22 @@
+# Performance
+
+## Resource Constraints
+
+The challenge allows a total of 1.5 CPU and 550MB RAM across all containers.
+
+## Actual Usage
+
+| Metric | Limit | Actual | Margin |
+|--------|-------|--------|--------|
+| RAM | 550MB | ~250MB | 60% below limit |
+| Response time | - | < 800ms | All requests |
+
+## Results
+
+- All requests completed under 800ms
+- Total RAM usage of approximately 250MB, which is 60% below the 550MB limit
+- Built for learning purposes
+
+## Stress Testing
+
+Load tests are run using the shared [rinha2-back-end-k6L(https://github.com/jonathanperis/rinha2-back-end-k6.md) test suite, which simulates concurrent users performing debits, credits, validations, and statement queries.

--- a/wiki/index.md
+++ b/wiki/index.md
@@ -1,0 +1,24 @@
+# rinha2-back-end-go
+
+Go 1.25 implementation for the Rinha de Backend 2024/Q1 challenge. Manages a fictional bank API with transaction processing and balance statements under strict resource constraints (1.5 CPU, 550MB RAM total across all containers).
+
+## Wiki Pages
+
+| Page | Description |
+|------|-------------|
+| [Challenge](Challenge) | What is Rinha de Backend 2024/Q1 |
+| [Architecture](Architecture) | Stack, services, resource constraints |
+| [Getting StartedL(Getting-Started.md) | Prerequisites and how to run |
+| [Performance](Performance) | Results, benchmarks, resource usage |
+| [CI/CD PipelineL(CI-CD-Pipeline.md) | GitHub Actions workflows |
+
+## Key Features
+
+- Minimal single-file API implementation (~221 lines of Go)
+- chi/v5 router with pgx/v5 PostgreSQL driver
+- PostgreSQL stored procedures for server-side business logic
+- All requests under 800ms at 250MB RAM usage
+
+---
+
+*[GitHubL(https://github.com/jonathanperis/rinha2-back-end-go.md) · [Jonathan Peris](https://jonathanperis.github.io/)*


### PR DESCRIPTION
Migrate GitHub wiki markdown files to `wiki/` folder in main repo. Wiki will be disabled after merge.