### PR TITLE
fix: add docs-layout wrapper, fix CI paths-filter

### DIFF
--- a/.github/workflows/build-check.yml
+++ b/.github/workflows/build-check.yml
@@ -15,8 +15,13 @@ jobs:
     outputs:
       relevant: ${{ steps.changes.outputs.src }}
     steps:
+      - name: Checkout Repository
+        uses: actions/checkout@v6
+        with:
+          fetch-depth: 0
+
       - name: Detect relevant changes
-        uses: dorny/paths-filter@v3
+        uses: dorny/paths-filter@v4
         id: changes
         with:
           filters: |

--- a/.github/workflows/codeql.yml
+++ b/.github/workflows/codeql.yml
@@ -18,8 +18,13 @@ jobs:
     outputs:
       relevant: ${{ steps.changes.outputs.src }}
     steps:
+      - name: Checkout Repository
+        uses: actions/checkout@v6
+        with:
+          fetch-depth: 0
+
       - name: Detect relevant changes
-        uses: dorny/paths-filter@v3
+        uses: dorny/paths-filter@v4
         id: changes
         with:
           filters: |

--- a/docs/src/pages/docs/[...slug].astro
+++ b/docs/src/pages/docs/[...slug].astro
@@ -41,7 +41,8 @@ const backHomeUrl = base.replace(/\/$/, '') + '/';
 ---
 
 <BaseLayout title={pageTitle}>
-  <div class="mobile-header">
+  <div class="docs-layout">
+    <div class="mobile-header">
     <button class="menu-toggle" id="menuToggle" aria-label="Toggle Menu" aria-controls="sidebar" aria-expanded="false">
       <span></span>
       <span></span>
@@ -93,6 +94,7 @@ const backHomeUrl = base.replace(/\/$/, '') + '/';
         );
       })}
     </main>
+  </div>
   </div>
 
   {requestedSlug && <script is:inline define:vars={{ slug: requestedSlug }}>window.__docsSlug = slug;</script>}


### PR DESCRIPTION
## Summary

Two fixes for issues found after merging #46:

1. **Missing `docs-layout` wrapper** — `[...slug].astro` was missing the `<div class="docs-layout">` wrapper, causing all CSS selectors (`.docs-layout .sidebar`, `.docs-layout .content`, etc.) to fail. Page rendered without any styling.

2. **CI filter jobs missing checkout step** — `dorny/paths-filter@v3` was failing with git exit code 128 because filter jobs had no checkout step. Also updated to `v4` for Node.js 24 compatibility.

## Files Changed

- `docs/src/pages/docs/[...slug].astro` — added `<div class="docs-layout">` wrapper
- `.github/workflows/codeql.yml` — added checkout step, updated to paths-filter@v4
- `.github/workflows/build-check.yml` — added checkout step, updated to paths-filter@v4

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Chores**
  * Updated GitHub Actions workflow automation tools to latest versions for improved stability and security.

* **Style**
  * Restructured documentation page layout with improved HTML markup for better styling consistency.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->