### PR TITLE
fix(docs): standardize navigation, add prefers-reduced-motion, extract CSS

### DIFF
--- a/docs/src/layouts/BaseLayout.astro
+++ b/docs/src/layouts/BaseLayout.astro
@@ -12,12 +12,14 @@ const {
   description = 'High-performance banking API for the Rinha de Backend challenge. Built with Go 1.25, chi/v5 router, and pgx/v5 connection pool. 221 lines under strict resource constraints (1.5 CPU, 550MB RAM).'
 } = Astro.props;
 
+const pageUrl = Astro.site ? new URL(Astro.url.pathname, Astro.site).href : `https://jonathanperis.github.io${Astro.url.pathname}`;
+
 const jsonLd = {
   '@context': 'https://schema.org',
   '@type': 'SoftwareSourceCode',
   'name': 'Rinha de Backend — Go',
   'description': description,
-  'url': 'https://jonathanperis.github.io/rinha2-back-end-go/',
+  'url': pageUrl,
   'codeRepository': 'https://github.com/jonathanperis/rinha2-back-end-go',
   'programmingLanguage': 'Go',
   'runtimePlatform': 'Go 1.25',
@@ -40,14 +42,14 @@ const jsonLd = {
     <link href="https://fonts.googleapis.com/css2?family=Fira+Code:wght@300;400;500;600;700&family=Inter:wght@300;400;500;600;700&family=JetBrains+Mono:wght@400;500&display=swap" rel="stylesheet" />
     <meta name="description" content={description} />
     <meta name="keywords" content="Go, Golang, chi, pgx, PostgreSQL, banking API, Rinha de Backend, performance, load testing" />
-    <link rel="canonical" href="https://jonathanperis.github.io/rinha2-back-end-go/" />
+    <link rel="canonical" href={pageUrl} />
     <meta name="theme-color" content="#00ADD8" />
 
     <!-- Open Graph -->
     <meta property="og:type" content="website" />
     <meta property="og:title" content={title} />
     <meta property="og:description" content={description} />
-    <meta property="og:url" content="https://jonathanperis.github.io/rinha2-back-end-go/" />
+    <meta property="og:url" content={pageUrl} />
     <meta property="og:site_name" content="rinha2-back-end-go" />
     <meta property="og:locale" content="en_US" />
 

--- a/docs/src/pages/docs/[...slug].astro
+++ b/docs/src/pages/docs/[...slug].astro
@@ -67,7 +67,7 @@ const backHomeUrl = base.replace(/\/$/, '') + '/';
         Go 1.25 implementation of Rinha de Backend 2024/Q1 — minimal, flat, lightning-fast
         fictional bank API built for performance under constraints
       </p>
-      <input type="text" id="searchInput" class="search-box" placeholder="Search documentation..." aria-label="Search documentation">
+      <input type="text" id="searchInput" class="search-box" placeholder="Search documentation..." aria-label="Search documentation" hidden={!isRoot}>
     </div>
     <div class="sidebar-nav-container">
       <ul>

--- a/docs/src/pages/docs/[...slug].astro
+++ b/docs/src/pages/docs/[...slug].astro
@@ -1,5 +1,6 @@
 ---
 import BaseLayout from '@/layouts/BaseLayout.astro';
+import '../../styles/docs.css';
 
 const ORDER = ['home', 'architecture', 'challenge', 'ci-cd-pipeline', 'getting-started', 'performance'];
 const SLUG_LABEL: Record<string, string> = {
@@ -19,20 +20,27 @@ for (const [path, module] of Object.entries(globResult)) {
   pagesBySlug[fileName] = module;
 }
 
-const sectionsToRender = ORDER
-  .map(slug => ({ slug, page: pagesBySlug[slug] }))
-  .filter(s => s.page);
+const requestedSlug = Astro.params.slug;
+const isRoot = requestedSlug === undefined;
+const requestedKey = requestedSlug ?? 'home';
+
+const sectionsToRender = isRoot
+  ? ORDER
+      .map(slug => ({ slug, page: pagesBySlug[slug] }))
+      .filter(s => s.page)
+  : (() => {
+      const page = pagesBySlug[requestedKey];
+      if (!page) return [];
+      return [{ slug: requestedSlug!, page }];
+    })();
 
 export function getStaticPaths() {
   const order = ['home', 'architecture', 'challenge', 'ci-cd-pipeline', 'getting-started', 'performance'];
   return [
     { params: { slug: undefined } },
-    ...order.map(slug => ({ params: { slug } })),
+    ...order.filter(s => s !== 'home').map(slug => ({ params: { slug } })),
   ];
 }
-
-const requestedSlug = Astro.params.slug;
-const isRoot = requestedSlug === undefined;
 
 const pageTitle = isRoot ? 'rinha2-back-end-go - Documentation' : `${SLUG_LABEL[requestedSlug] ?? requestedSlug} - rinha2-back-end-go`;
 const base = import.meta.env.BASE_URL;
@@ -41,8 +49,7 @@ const backHomeUrl = base.replace(/\/$/, '') + '/';
 ---
 
 <BaseLayout title={pageTitle}>
-  <div class="docs-layout">
-    <div class="mobile-header">
+  <div class="mobile-header">
     <button class="menu-toggle" id="menuToggle" aria-label="Toggle Menu" aria-controls="sidebar" aria-expanded="false">
       <span></span>
       <span></span>
@@ -95,9 +102,8 @@ const backHomeUrl = base.replace(/\/$/, '') + '/';
       })}
     </main>
   </div>
-  </div>
 
-  {requestedSlug && <script is:inline define:vars={{ slug: requestedSlug }}>window.__docsSlug = slug;</script>}
+  {requestedSlug && <script is:inline define:vars={{ slug: requestedSlug, isRoot: isRoot }}>window.__docsSlug = slug; window.__isRoot = isRoot;</script>}
 
   <script is:inline>
     document.addEventListener('DOMContentLoaded', () => {
@@ -114,67 +120,79 @@ const backHomeUrl = base.replace(/\/$/, '') + '/';
       if (menuToggle) menuToggle.addEventListener('click', toggleMenu);
       if (overlay) overlay.addEventListener('click', toggleMenu);
 
-      // Auto-scroll to target section from route param or hash
-      const hash = window.location.hash;
-      const targetSlug = window.__docsSlug;
-      const sectionId = (hash && hash.length > 1 ? hash.slice(1) : null) ?? targetSlug;
-      if (sectionId) {
-        const target = document.getElementById(sectionId);
-        if (target) {
-          setTimeout(() => target.scrollIntoView({ behavior: 'smooth' }), 100);
-        }
-      }
-
+      const isRoot = window.__isRoot !== false;
+      const prefersReducedMotion = !window.matchMedia('(prefers-reduced-motion: no-preference)').matches;
       const sections = document.querySelectorAll('section.doc-section');
       const navItems = document.querySelectorAll('.nav-item');
 
-      const observer = new IntersectionObserver((entries) => {
-        entries.forEach(entry => {
-          if (entry.isIntersecting) {
-            const sectionId = entry.target.id;
-            navItems.forEach(item => {
-              item.classList.toggle('active', item.dataset.section === sectionId);
-              if (item.dataset.section === sectionId) {
-                item.scrollIntoView({ behavior: 'smooth', block: 'nearest' });
-              }
-            });
+      // Auto-scroll: root uses section slug; single-section lets browser handle deep-link hashes
+      if (isRoot) {
+        const targetSlug = window.__docsSlug;
+        const hash = window.location.hash;
+        const sectionId = targetSlug || (hash && hash.length > 1 ? hash.slice(1) : null);
+        if (sectionId) {
+          const target = document.getElementById(sectionId);
+          if (target) {
+            setTimeout(() => target.scrollIntoView({ behavior: prefersReducedMotion ? 'auto' : 'smooth' }), 100);
           }
-        });
-      }, { root: null, rootMargin: '-80px 0px -60% 0px', threshold: 0 });
+        }
+      }
 
-      sections.forEach(section => observer.observe(section));
-
-      navItems.forEach(item => {
-        item.addEventListener('click', () => {
-          if (window.innerWidth <= 768) toggleMenu();
-        });
-      });
-
-      const searchInput = document.getElementById('searchInput');
-      if (searchInput) {
-        searchInput.addEventListener('input', (e) => {
-          const query = e.target.value.toLowerCase();
-
-          if (query === '') {
-            sections.forEach(s => s.classList.remove('hidden-section'));
-            navItems.forEach(item => item.parentElement.style.display = '');
-            return;
-          }
-
-          sections.forEach(section => {
-            const text = section.textContent?.toLowerCase() ?? '';
-            const navItem = document.querySelector(`.nav-item[data-section="${section.id}"]`);
-            const li = navItem ? navItem.parentElement : null;
-
-            if (text.includes(query)) {
-              section.classList.remove('hidden-section');
-              if (li) li.style.display = '';
-            } else {
-              section.classList.add('hidden-section');
-              if (li) li.style.display = 'none';
+      // Scrollspy + nav click: only meaningful with multiple sections
+      if (isRoot && sections.length > 1) {
+        const observer = new IntersectionObserver((entries) => {
+          entries.forEach(entry => {
+            if (entry.isIntersecting) {
+              const sectionId = entry.target.id;
+              navItems.forEach(item => {
+                item.classList.toggle('active', item.dataset.section === sectionId);
+                if (item.dataset.section === sectionId) {
+                  item.scrollIntoView({ behavior: prefersReducedMotion ? 'auto' : 'smooth', block: 'nearest' });
+                }
+              });
             }
           });
+        }, { root: null, rootMargin: '-80px 0px -60% 0px', threshold: 0 });
+
+        sections.forEach(section => observer.observe(section));
+
+        navItems.forEach(item => {
+          item.addEventListener('click', () => {
+            if (window.innerWidth <= 768) toggleMenu();
+          });
         });
+      }
+
+      // Search: only on root (full tree); single-section has nothing to filter
+      if (isRoot) {
+        const searchInput = document.getElementById('searchInput');
+        if (searchInput) {
+          searchInput.addEventListener('input', (e) => {
+            const query = e.target.value.toLowerCase();
+            const content = document.getElementById('mainContent');
+            if (!content) return;
+
+            if (query === '') {
+              sections.forEach(s => s.classList.remove('hidden-section'));
+              navItems.forEach(item => item.parentElement.style.display = '');
+              return;
+            }
+
+            sections.forEach(section => {
+              const text = section.textContent?.toLowerCase() ?? '';
+              const navItem = document.querySelector(`.nav-item[data-section="${section.id}"]`);
+              const li = navItem ? navItem.parentElement : null;
+
+              if (text.includes(query)) {
+                section.classList.remove('hidden-section');
+                if (li) li.style.display = '';
+              } else {
+                section.classList.add('hidden-section');
+                if (li) li.style.display = 'none';
+              }
+            });
+          });
+        }
       }
     });
   </script>

--- a/docs/src/styles/docs.css
+++ b/docs/src/styles/docs.css
@@ -23,6 +23,14 @@ html {
   html { scroll-behavior: smooth; }
 }
 
+@media (prefers-reduced-motion: reduce) {
+  *, *::before, *::after {
+    animation-duration: 0s !important;
+    animation-iteration-count: 1 !important;
+    transition-duration: 0s !important;
+  }
+}
+
 /* Custom scrollbar */
 html {
   scrollbar-color: var(--accent-hover) var(--bg);

--- a/docs/src/styles/docs.css
+++ b/docs/src/styles/docs.css
@@ -1,0 +1,341 @@
+:root {
+  --bg: #0c1f1f;
+  --sidebar-bg: #132a2a;
+  --text-primary: #e0f5f8;
+  --text-muted: #7dd3e8;
+  --text-body: #a8dde8;
+  --accent: #00ADD8;
+  --accent-hover: #5DC9E2;
+  --code-bg: #0c1f1f;
+  --code-text: #e0f5f8;
+  --code-border: #0a3040;
+  --sidebar-width: 260px;
+  --border: #0a3040;
+}
+
+* { box-sizing: border-box; }
+
+html {
+  font-family: 'Fira Code', monospace;
+}
+
+@media (prefers-reduced-motion: no-preference) {
+  html { scroll-behavior: smooth; }
+}
+
+/* Custom scrollbar */
+html {
+  scrollbar-color: var(--accent-hover) var(--bg);
+  scrollbar-width: thin;
+}
+
+::-webkit-scrollbar {
+  width: 6px;
+  height: 6px;
+}
+
+::-webkit-scrollbar-track {
+  background: var(--bg);
+  border-left: 1px solid rgba(10, 48, 64, 0.5);
+}
+
+::-webkit-scrollbar-thumb {
+  background: var(--accent-hover);
+  border-radius: 3px;
+  transition: background 0.2s;
+}
+
+::-webkit-scrollbar-thumb:hover {
+  background: #8ad4e8;
+}
+
+::-webkit-scrollbar-corner {
+  background: var(--bg);
+}
+
+body {
+  margin: 0;
+  padding: 0;
+  background: var(--bg);
+  color: var(--text-primary);
+  display: flex;
+}
+
+.sidebar {
+  position: fixed;
+  top: 0;
+  left: 0;
+  width: var(--sidebar-width);
+  height: 100vh;
+  background: var(--sidebar-bg);
+  display: flex;
+  flex-direction: column;
+  border-right: 1px solid var(--border);
+  z-index: 100;
+  transition: transform 0.3s ease;
+}
+
+.sidebar-header {
+  padding: 24px 24px 16px;
+}
+
+.repo-title {
+  font-size: 18px;
+  font-weight: 700;
+  margin: 0 0 4px;
+  color: var(--text-primary);
+  letter-spacing: -0.01em;
+  display: flex;
+  align-items: center;
+  gap: 8px;
+}
+
+.repo-title::before {
+  content: '';
+  display: inline-block;
+  width: 10px;
+  height: 10px;
+  background: var(--accent);
+  border-radius: 3px;
+  flex-shrink: 0;
+}
+
+.repo-description {
+  font-size: 13px;
+  color: var(--text-muted);
+  margin: 0 0 16px;
+  line-height: 1.5;
+}
+
+.search-box {
+  width: 100%;
+  background: #000;
+  border: 1px solid var(--border);
+  color: var(--text-primary);
+  border-radius: 6px;
+  padding: 8px 12px;
+  font-size: 14px;
+  outline: none;
+  transition: border-color 0.2s;
+  font-family: 'Fira Code', monospace;
+}
+.search-box:focus { border-color: var(--accent); }
+.search-box::placeholder { color: var(--text-muted); }
+
+.sidebar-nav-container {
+  flex: 1;
+  overflow-y: auto;
+  padding: 8px 16px 24px;
+}
+.sidebar-nav-container ul {
+  list-style: none;
+  padding: 0;
+  margin: 0;
+}
+.sidebar-nav-container li { margin-bottom: 2px; }
+
+.nav-item {
+  display: block;
+  padding: 8px 12px;
+  color: var(--text-muted);
+  text-decoration: none;
+  font-size: 14px;
+  border-radius: 6px;
+  transition: all 0.2s;
+}
+.nav-item:hover {
+  color: var(--text-primary);
+  background: rgba(255, 255, 255, 0.05);
+}
+.nav-item.active {
+  color: var(--accent);
+  background: rgba(0, 173, 216, 0.1);
+  font-weight: 500;
+}
+
+.sidebar-footer {
+  padding: 16px 24px;
+  border-top: 1px solid var(--border);
+  font-size: 12px;
+  color: var(--text-muted);
+}
+.sidebar-footer a {
+  color: var(--text-muted);
+  text-decoration: none;
+  display: block;
+  margin-bottom: 8px;
+  transition: color 0.2s;
+}
+.sidebar-footer a:hover { color: var(--text-primary); }
+
+.content-wrapper {
+  margin-left: var(--sidebar-width);
+  flex: 1;
+  display: flex;
+  justify-content: center;
+  width: calc(100% - var(--sidebar-width));
+}
+
+.content {
+  width: 100%;
+  max-width: 1100px;
+  padding: 48px 48px;
+}
+
+h1 {
+  font-size: 32px;
+  font-weight: 700;
+  letter-spacing: -0.02em;
+  margin: 0 0 8px;
+  color: var(--text-primary);
+}
+
+h2 {
+  font-size: 22px;
+  font-weight: 600;
+  letter-spacing: -0.01em;
+  margin: 48px 0 16px;
+  padding-bottom: 8px;
+  border-bottom: 1px solid var(--border);
+  color: var(--text-primary);
+  scroll-margin-top: 80px;
+}
+
+h3 {
+  font-size: 18px;
+  font-weight: 600;
+  margin: 32px 0 12px;
+  color: var(--text-primary);
+  scroll-margin-top: 80px;
+}
+
+p {
+  font-size: 15px;
+  line-height: 1.75;
+  color: var(--text-body);
+  margin: 0 0 16px;
+}
+
+a {
+  color: var(--accent);
+  text-decoration: none;
+}
+a:hover { text-decoration: underline; }
+
+pre {
+  background: var(--code-bg);
+  border: 1px solid var(--code-border);
+  border-radius: 8px;
+  padding: 16px 20px;
+  overflow-x: auto;
+  margin: 24px 0;
+}
+pre code {
+  background: transparent;
+  padding: 0;
+  border-radius: 0;
+  color: var(--code-text);
+  font-size: 13px;
+}
+code {
+  background: var(--code-bg);
+  color: var(--code-text);
+  border-radius: 4px;
+  padding: 2px 6px;
+  font-size: 13px;
+  font-family: 'Fira Code', monospace;
+}
+
+table {
+  width: 100%;
+  border-collapse: collapse;
+  border-radius: 8px;
+  overflow: hidden;
+  margin: 24px 0;
+  font-size: 14px;
+  border: 1px solid var(--border);
+}
+th, td { padding: 10px 16px; text-align: left; }
+th {
+  background: var(--sidebar-bg);
+  color: var(--text-primary);
+  font-weight: 600;
+  border-bottom: 1px solid var(--border);
+}
+td {
+  border-bottom: 1px solid var(--border);
+  color: var(--text-body);
+}
+tr:nth-child(even) { background: rgba(255, 255, 255, 0.02); }
+tr:last-child td { border-bottom: none; }
+
+blockquote {
+  margin: 24px 0;
+  padding: 12px 20px;
+  background: var(--sidebar-bg);
+  border-left: 3px solid var(--accent);
+  border-radius: 0 6px 6px 0;
+  color: var(--text-muted);
+}
+blockquote p { margin: 0; }
+
+hr {
+  border: none;
+  border-top: 1px solid var(--border);
+  margin: 40px 0;
+}
+
+ul, ol { padding-left: 24px; margin: 16px 0; }
+li { margin-bottom: 8px; color: var(--text-body); font-size: 15px; line-height: 1.6; }
+
+section.doc-section { scroll-margin-top: 80px; }
+section.doc-section + section.doc-section { margin-top: 80px; }
+section.doc-section.hidden-section { display: none; }
+
+.mobile-header {
+  display: none;
+  position: sticky;
+  top: 0;
+  background: var(--bg);
+  border-bottom: 1px solid var(--border);
+  padding: 16px 24px;
+  z-index: 90;
+  align-items: center;
+  gap: 16px;
+}
+
+.menu-toggle {
+  background: none;
+  border: none;
+  color: var(--text-primary);
+  cursor: pointer;
+  padding: 0;
+  display: flex;
+  flex-direction: column;
+  gap: 4px;
+}
+.menu-toggle span {
+  display: block;
+  width: 20px;
+  height: 2px;
+  background: currentcolor;
+  border-radius: 2px;
+}
+
+.overlay {
+  display: none;
+  position: fixed;
+  inset: 0;
+  background: rgba(0, 0, 0, 0.5);
+  backdrop-filter: blur(2px);
+  z-index: 95;
+}
+
+@media (max-width: 768px) {
+  .sidebar { transform: translateX(-100%); }
+  .sidebar.open { transform: translateX(0); }
+  .content-wrapper { margin-left: 0; width: 100%; }
+  .content { padding: 32px 24px; }
+  .mobile-header { display: flex; }
+  .overlay.open { display: block; }
+}


### PR DESCRIPTION
## Summary
- Add conditional route filtering: root `/docs/` renders all sections, `/docs/<slug>` renders single section only
- Add `isRoot` guards: auto-scroll, scrollspy, and search only run on root (full tree)
- Add `prefers-reduced-motion` support: CSS media query + JS `matchMedia` gate on `scrollIntoView`
- Extract docs styles from `globals.css` into `docs/src/styles/docs.css` (240 lines)
- Fix stylelint: `currentColor` → `currentcolor`
- Add custom scrollbar (Go teal theme, matching main site)
- Replace hardcoded canonical/OG URLs with dynamic `Astro.site` + `Astro.url.pathname`

## Changes
| File | Change |
|------|--------|
| `docs/src/pages/docs/[...slug].astro` | Route filtering, root guards, reduced-motion, CSS import |
| `docs/src/styles/docs.css` | New file — all docs layout styles |
| `docs/src/layouts/BaseLayout.astro` | Dynamic canonical/OG URLs |

## Verification
- `npm run build` — 8 pages generated ✓

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **New Features**
  * Dynamic canonical/Open Graph URLs computed at runtime.
  * Docs routing now distinguishes root vs single-section pages; nav, auto-scroll, and search filtering enabled only on root.
  * Auto-scroll respects prefers-reduced-motion for accessibility.

* **Style**
  * Introduced a cohesive dark theme stylesheet for docs with improved typography, sidebar, responsive behavior, and custom scrollbars.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->