### PR TITLE
feat(docs): add categorized sidebar with search filter support

### DIFF
--- a/docs/src/pages/docs/[...slug].astro
+++ b/docs/src/pages/docs/[...slug].astro
@@ -40,7 +40,8 @@ const sectionsToRender = isRoot
     })();
 
 export function getStaticPaths() {
-  const order = ['home', 'architecture', 'challenge', 'ci-cd-pipeline', 'getting-started', 'performance'];
+  // SECTION_CATEGORIES.flatMap(({ ids }) => ids) — duplicated due to Astro hoisting
+  const order = ['home', 'challenge', 'architecture', 'getting-started', 'performance', 'ci-cd-pipeline'];
   return [
     { params: { slug: undefined } },
     ...order.filter(s => s !== 'home').map(slug => ({ params: { slug } })),
@@ -184,7 +185,10 @@ const backHomeUrl = base.replace(/\/$/, '') + '/';
 
             if (query === '') {
               sections.forEach(s => s.classList.remove('hidden-section'));
-              navItems.forEach(item => item.parentElement.style.display = '');
+              navItems.forEach(item => {
+                item.style.display = '';
+                item.parentElement.style.display = '';
+              });
               document.querySelectorAll('.sidebar-category-group').forEach(group => {
                 group.style.display = '';
                 const catLabel = group.querySelector('.sidebar-category');

--- a/docs/src/pages/docs/[...slug].astro
+++ b/docs/src/pages/docs/[...slug].astro
@@ -2,7 +2,12 @@
 import BaseLayout from '@/layouts/BaseLayout.astro';
 import '../../styles/docs.css';
 
-const ORDER = ['home', 'architecture', 'challenge', 'ci-cd-pipeline', 'getting-started', 'performance'];
+const SECTION_CATEGORIES = [
+  { label: '', ids: ['home'] },
+  { label: 'Overview', ids: ['challenge', 'architecture'] },
+  { label: 'Develop', ids: ['getting-started', 'performance', 'ci-cd-pipeline'] },
+];
+
 const SLUG_LABEL: Record<string, string> = {
   home: 'Home',
   architecture: 'Architecture',
@@ -25,7 +30,7 @@ const isRoot = requestedSlug === undefined;
 const requestedKey = requestedSlug ?? 'home';
 
 const sectionsToRender = isRoot
-  ? ORDER
+  ? SECTION_CATEGORIES.flatMap(cat => cat.ids)
       .map(slug => ({ slug, page: pagesBySlug[slug] }))
       .filter(s => s.page)
   : (() => {
@@ -70,18 +75,23 @@ const backHomeUrl = base.replace(/\/$/, '') + '/';
       <input type="text" id="searchInput" class="search-box" placeholder="Search documentation..." aria-label="Search documentation" hidden={!isRoot}>
     </div>
     <div class="sidebar-nav-container">
-      <ul>
-        {ORDER.map(slug => {
-          const label = SLUG_LABEL[slug];
-          return (
-            <li>
-              <a href={`${docsBase}/#${slug}`} class="nav-item" data-section={slug}>
-                {label}
-              </a>
-            </li>
-          );
-        })}
-      </ul>
+      {SECTION_CATEGORIES.map((cat) => {
+        const catIds = cat.ids;
+        return (
+          <div class="sidebar-category-group" data-category>
+            {cat.label && <div class="sidebar-category">{cat.label}</div>}
+            <ul>
+              {catIds.map((id) => (
+                <li>
+                  <a class="nav-item" href={`${docsBase}/#${id}`} data-nav-id={id}>
+                    {SLUG_LABEL[id]}
+                  </a>
+                </li>
+              ))}
+            </ul>
+          </div>
+        );
+      })}
     </div>
     <div class="sidebar-footer">
       <a href={backHomeUrl} class="back-home">← Back to home</a>
@@ -145,8 +155,8 @@ const backHomeUrl = base.replace(/\/$/, '') + '/';
             if (entry.isIntersecting) {
               const sectionId = entry.target.id;
               navItems.forEach(item => {
-                item.classList.toggle('active', item.dataset.section === sectionId);
-                if (item.dataset.section === sectionId) {
+                item.classList.toggle('active', item.dataset.navId === sectionId);
+                if (item.dataset.navId === sectionId) {
                   item.scrollIntoView({ behavior: prefersReducedMotion ? 'auto' : 'smooth', block: 'nearest' });
                 }
               });
@@ -175,12 +185,17 @@ const backHomeUrl = base.replace(/\/$/, '') + '/';
             if (query === '') {
               sections.forEach(s => s.classList.remove('hidden-section'));
               navItems.forEach(item => item.parentElement.style.display = '');
+              document.querySelectorAll('.sidebar-category-group').forEach(group => {
+                group.style.display = '';
+                const catLabel = group.querySelector('.sidebar-category');
+                if (catLabel) catLabel.style.display = '';
+              });
               return;
             }
 
             sections.forEach(section => {
               const text = section.textContent?.toLowerCase() ?? '';
-              const navItem = document.querySelector(`.nav-item[data-section="${section.id}"]`);
+              const navItem = document.querySelector(`.nav-item[data-nav-id="${section.id}"]`);
               const li = navItem ? navItem.parentElement : null;
 
               if (text.includes(query)) {
@@ -190,6 +205,22 @@ const backHomeUrl = base.replace(/\/$/, '') + '/';
                 section.classList.add('hidden-section');
                 if (li) li.style.display = 'none';
               }
+            });
+
+            // Hide empty categories
+            document.querySelectorAll('.sidebar-category-group').forEach(group => {
+              const items = group.querySelectorAll('.nav-item');
+              let visibleCount = 0;
+              items.forEach(item => {
+                const id = item.dataset.navId;
+                const sec = document.getElementById(id ?? '');
+                const vis = !sec || !sec.classList.contains('hidden-section');
+                item.style.display = vis ? '' : 'none';
+                if (vis) visibleCount++;
+              });
+              const catLabel = group.querySelector('.sidebar-category');
+              if (catLabel) catLabel.style.display = visibleCount === 0 ? 'none' : '';
+              group.style.display = visibleCount === 0 ? 'none' : '';
             });
           });
         }

--- a/docs/src/styles/docs.css
+++ b/docs/src/styles/docs.css
@@ -142,6 +142,16 @@ body {
 }
 .sidebar-nav-container li { margin-bottom: 2px; }
 
+.sidebar-category {
+  font-size: 11px;
+  font-weight: 600;
+  text-transform: uppercase;
+  letter-spacing: 0.08em;
+  color: var(--text-muted);
+  padding: 12px 12px 4px;
+  margin-top: 8px;
+}
+
 .nav-item {
   display: block;
   padding: 8px 12px;


### PR DESCRIPTION
## Summary
- Add `SECTION_CATEGORIES` array with Overview/Develop groupings
- Replace flat sidebar with categorized rendering
- Search now hides empty category groups and labels
- Add `.sidebar-category` CSS styles

## Changes
- `docs/src/pages/docs/[...slug].astro`: +41/-17 lines (categorized sidebar, search)
- `docs/src/styles/docs.css`: +11 lines (category label styles)

## Verification
- `npm run build` ✓

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **UX Improvements**
  * Reorganized documentation sidebar into categorized groups for clearer navigation and better discoverability.
  * Updated client-side navigation behavior and search handling so filtering hides irrelevant sections and restores grouped categories when cleared.

* **Style**
  * Added visual styling for sidebar category headings to enhance hierarchy and readability.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->