### PR TITLE
refactor(docs): derive SECTION_ORDER and add build-time assertion

### DIFF
--- a/docs/src/pages/docs/[...slug].astro
+++ b/docs/src/pages/docs/[...slug].astro
@@ -8,6 +8,8 @@ const SECTION_CATEGORIES = [
   { label: 'Develop', ids: ['getting-started', 'performance', 'ci-cd-pipeline'] },
 ];
 
+const SECTION_ORDER = SECTION_CATEGORIES.flatMap(({ ids }) => ids);
+
 const SLUG_LABEL: Record<string, string> = {
   home: 'Home',
   architecture: 'Architecture',
@@ -25,6 +27,19 @@ for (const [path, module] of Object.entries(globResult)) {
   pagesBySlug[fileName] = module;
 }
 
+// Build-time assertion: validate SECTION_CATEGORIES IDs against discovered slugs
+const availableSlugs = new Set(Object.keys(pagesBySlug));
+for (const cat of SECTION_CATEGORIES) {
+  for (const id of cat.ids) {
+    if (!availableSlugs.has(id)) {
+      const catName = cat.label || 'root';
+      throw new Error(
+        `SECTION_CATEGORIES references id "${id}" (category: "${catName}") but no matching wiki/${id}.md was found. Available slugs: ${Array.from(availableSlugs).join(', ')}`
+      );
+    }
+  }
+}
+
 const requestedSlug = Astro.params.slug;
 const isRoot = requestedSlug === undefined;
 const requestedKey = requestedSlug ?? 'home';
@@ -40,11 +55,9 @@ const sectionsToRender = isRoot
     })();
 
 export function getStaticPaths() {
-  // SECTION_CATEGORIES.flatMap(({ ids }) => ids) — duplicated due to Astro hoisting
-  const order = ['home', 'challenge', 'architecture', 'getting-started', 'performance', 'ci-cd-pipeline'];
   return [
     { params: { slug: undefined } },
-    ...order.filter(s => s !== 'home').map(slug => ({ params: { slug } })),
+    ...SECTION_ORDER.filter(s => s !== 'home').map(slug => ({ params: { slug } })),
   ];
 }
 


### PR DESCRIPTION
## Summary
- Derive `SECTION_ORDER` from `SECTION_CATEGORIES.flatMap(({ ids }) => ids)` — eliminates duplicate hardcoded array
- Add build-time assertion validating all category IDs exist as `wiki/*.md` files
- Replace hardcoded `order` array in `getStaticPaths()` with `SECTION_ORDER`
- Catches drift when wiki files are added/renamed without updating categories

## Changes
- `docs/src/pages/docs/[...slug].astro`: Add `SECTION_ORDER`, build-time assertion, update `getStaticPaths`

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Chores**
  * Improved internal documentation section ordering logic and added build-time validation to ensure documentation completeness.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->