### PR TITLE
fix(docs): extract SECTION_CATEGORIES to sidebar.config.ts for Astro hoisting

### DIFF
--- a/docs/src/pages/docs/[...slug].astro
+++ b/docs/src/pages/docs/[...slug].astro
@@ -1,14 +1,7 @@
 ---
 import BaseLayout from '@/layouts/BaseLayout.astro';
 import '../../styles/docs.css';
-
-const SECTION_CATEGORIES = [
-  { label: '', ids: ['home'] },
-  { label: 'Overview', ids: ['challenge', 'architecture'] },
-  { label: 'Develop', ids: ['getting-started', 'performance', 'ci-cd-pipeline'] },
-];
-
-const SECTION_ORDER = SECTION_CATEGORIES.flatMap(({ ids }) => ids);
+import { SECTION_CATEGORIES, SECTION_ORDER } from './sidebar.config';
 
 const SLUG_LABEL: Record<string, string> = {
   home: 'Home',

--- a/docs/src/pages/docs/sidebar.config.ts
+++ b/docs/src/pages/docs/sidebar.config.ts
@@ -1,0 +1,7 @@
+export const SECTION_CATEGORIES = [
+  { label: "", ids: ["home"] },
+  { label: "Overview", ids: ["challenge", "architecture"] },
+  { label: "Develop", ids: ["getting-started", "performance", "ci-cd-pipeline"] },
+] as const;
+
+export const SECTION_ORDER = SECTION_CATEGORIES.flatMap(({ ids }) => ids);


### PR DESCRIPTION
## Problem
Deploy fails with `SECTION_ORDER is not defined` during static route generation.

## Root Cause
Astro hoists `getStaticPaths()` to module scope — it runs BEFORE frontmatter code executes. `SECTION_ORDER` defined in frontmatter is invisible to `getStaticPaths`. Only **imports** survive hoisting.

## Fix
- Extract `SECTION_CATEGORIES` + `SECTION_ORDER` to `sidebar.config.ts`
- Import in `[...slug].astro` — import survives hoisting
- `getStaticPaths` now references imported `SECTION_ORDER` — works correctly
- Build-time assertion stays in frontmatter (runs at render time, not hoisted)

## Files
- `docs/src/pages/docs/sidebar.config.ts` (new)
- `docs/src/pages/docs/[...slug].astro` (import + remove inline def)