### PR TITLE
fix(docs): exclude .astro-code from pre/code CSS rules

### DIFF
--- a/docs/src/pages/docs/[...slug].astro
+++ b/docs/src/pages/docs/[...slug].astro
@@ -1,14 +1,7 @@
 ---
 import BaseLayout from '@/layouts/BaseLayout.astro';
 import '../../styles/docs.css';
-
-const SECTION_CATEGORIES = [
-  { label: '', ids: ['home'] },
-  { label: 'Overview', ids: ['challenge', 'architecture'] },
-  { label: 'Develop', ids: ['getting-started', 'performance', 'ci-cd-pipeline'] },
-];
-
-const SECTION_ORDER = SECTION_CATEGORIES.flatMap(({ ids }) => ids);
+import { SECTION_CATEGORIES, SECTION_ORDER } from './sidebar.config';
 
 const SLUG_LABEL: Record<string, string> = {
   home: 'Home',

--- a/docs/src/pages/docs/sidebar.config.ts
+++ b/docs/src/pages/docs/sidebar.config.ts
@@ -1,0 +1,7 @@
+export const SECTION_CATEGORIES = [
+  { label: "", ids: ["home"] },
+  { label: "Overview", ids: ["challenge", "architecture"] },
+  { label: "Develop", ids: ["getting-started", "performance", "ci-cd-pipeline"] },
+] as const;
+
+export const SECTION_ORDER = SECTION_CATEGORIES.flatMap(({ ids }) => ids);

--- a/docs/src/styles/docs.css
+++ b/docs/src/styles/docs.css
@@ -240,7 +240,7 @@ a {
 }
 a:hover { text-decoration: underline; }
 
-pre {
+pre:not(.astro-code) {
   background: var(--code-bg);
   border: 1px solid var(--code-border);
   border-radius: 8px;
@@ -248,12 +248,18 @@ pre {
   overflow-x: auto;
   margin: 24px 0;
 }
-pre code {
+pre:not(.astro-code) code {
   background: transparent;
   padding: 0;
   border-radius: 0;
   color: var(--code-text);
   font-size: 13px;
+}
+pre.astro-code {
+  border: 1px solid var(--code-border);
+  border-radius: 8px;
+  padding: 16px 20px;
+  margin: 24px 0;
 }
 code {
   background: var(--code-bg);


### PR DESCRIPTION
## Problem\nCode blocks with syntax highlighting appear blank on deployed docs sites.\n\n## Root Cause\ndocs.css has pre { background: var(--code-bg) } and pre code { color: var(--code-text) } which override Astro/Shiki inline styles on pre.astro-code elements.\n\n## Fix\nChanged CSS selectors to pre:not(.astro-code) to preserve Shiki syntax highlighting.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Style**
  * Updated code block styling for improved visual differentiation and consistency in documentation.

* **Refactor**
  * Reorganized documentation configuration structure for better maintainability.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->