### PR TITLE
fix(ci): deploy docs with bun

### DIFF
--- a/.github/workflows/deploy.yml
+++ b/.github/workflows/deploy.yml
@@ -15,4 +15,4 @@ jobs:
     uses: jonathanperis/.github/.github/workflows/pages-docs-deploy.yml@fb477c55fc80195745b4e1a362e23f5b174f7a23 # main
     secrets: inherit
     with:
-      package-manager: npm
+      package-manager: bun


### PR DESCRIPTION
## Summary
- Switch GitHub Pages docs deploy from npm to bun.
- Fix deploy failure after removing `docs/package-lock.json` from the normalized scaffold.

## Verification
- Workflow-only change.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Chores**
  * Updated site deployment configuration to use an alternative package manager for improved build efficiency.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->