### PR TITLE
fix(docs): clean code block highlights

### DIFF
--- a/docs/src/styles/docs.css
+++ b/docs/src/styles/docs.css
@@ -248,7 +248,7 @@ pre:not(.astro-code) {
   overflow-x: auto;
   margin: 24px 0;
 }
-pre:not(.astro-code) code {
+pre:not(.astro-code) > code {
   background: transparent;
   padding: 0;
   border-radius: 0;
@@ -261,7 +261,13 @@ pre.astro-code {
   padding: 16px 20px;
   margin: 24px 0;
 }
-code {
+pre.astro-code > code {
+  background: transparent;
+  padding: 0;
+  border-radius: 0;
+  color: inherit;
+}
+:not(pre) > code {
   background: var(--code-bg);
   color: var(--code-text);
   border-radius: 4px;

--- a/docs/src/styles/globals.css
+++ b/docs/src/styles/globals.css
@@ -872,7 +872,7 @@ footer a:hover {
   margin: 24px 0;
 }
 
-.docs-layout .doc-section pre code {
+.docs-layout .doc-section pre > code {
   background: transparent;
   padding: 0;
   border-radius: 0;
@@ -880,7 +880,7 @@ footer a:hover {
   font-size: 13px;
 }
 
-.docs-layout .doc-section code {
+.docs-layout .doc-section :not(pre) > code {
   background: var(--code-bg);
   color: var(--code-text);
   border-radius: 4px;


### PR DESCRIPTION
## Summary
- Keep inline code chip styling out of fenced code blocks.
- Reset Shiki `<pre><code>` content so code samples render without per-line highlight boxes.

## Validation
- `bun run build`
- `rtk git diff --check`