### PR TITLE
Improve landing page benchmark evidence design

### DIFF
--- a/.impeccable/critique/docs-src-pages-index-astro-2026-05-16.md
+++ b/.impeccable/critique/docs-src-pages-index-astro-2026-05-16.md
@@ -1,0 +1,246 @@
+# Impeccable Design Evaluation and Overhaul Plan
+
+Target: `docs/src/pages/index.astro`
+URL inspected locally: `http://127.0.0.1:4327/rinha2-back-end-go/`
+Repo state: main synced to `97ecd2e`, work continued on branch `chore/impeccable-design-context`.
+
+## Design Health Score
+
+| # | Heuristic | Score | Key issue |
+|---|---:|---:|---|
+| 1 | Visibility of system status | 3 | CI and report links exist, but headline metrics are not tied to a specific run. |
+| 2 | Match system / real world | 3 | Go benchmark identity is clear. Some generic neon-tech styling weakens precision. |
+| 3 | User control and freedom | 3 | Main routes are obvious. Historical reports need stronger information scent. |
+| 4 | Consistency and standards | 3 | Visual system is coherent. Go version is inconsistent between badge and metadata. |
+| 5 | Error prevention | 2 | Build-time report directory read has no guard. Claims lack nearby evidence context. |
+| 6 | Recognition rather than recall | 3 | Stack, docs, GitHub, and reports are visible. Report cards are repetitive. |
+| 7 | Flexibility and efficiency | 3 | Developers can jump to docs/source quickly. No current-run shortcut. |
+| 8 | Aesthetic and minimalist design | 2 | Strong base aesthetic, but gradient text, particles, glass nav, and emoji labels add template noise. |
+| 9 | Error recovery | 2 | No meaningful page-level fallback for missing reports or failed generated content. |
+| 10 | Help and documentation | 4 | Docs, GitHub, CI, and reports are present and easy to find. |
+| **Total** |  | **28/40** | **Good foundation, needs credibility-first visual tightening.** |
+
+## Anti-pattern verdict
+
+### LLM assessment
+
+This does not look like low-effort AI output, because the content is specific, the Go/Rinha context is real, and the archived stress reports create credibility. It does, however, carry several common AI-template tells: gradient text, ambient particles, glassy sticky nav, glowing cyan accents, emoji section labels, and repeated metric cards.
+
+The aesthetic to preserve is clear: dark Go teal, cyan instrumentation, monospace benchmark-console energy. The overhaul should not replace that. It should make the same aesthetic more disciplined.
+
+### Deterministic scan
+
+`npx impeccable detect --json docs/src/pages/index.astro docs/src/components/home docs/src/layouts/BaseLayout.astro` found:
+
+- `single-font`: only Fira Code is used across the page.
+
+A delegated automated pass later returned no findings in its environment, so treat this as a weak automated signal but a valid design concern. Mono-forward is right for this project, but hierarchy needs more role separation.
+
+### Source-backed issues
+
+- Gradient text in `.hero h1` at `docs/src/styles/globals.css:228-237` violates the loaded design law.
+- Go version mismatch: `Hero.astro` says Go 1.22; `index.astro`, `BaseLayout.astro`, and `CLAUDE.md` say Go 1.25.
+- Landing animations have no `prefers-reduced-motion` accommodation in `globals.css`.
+- Hover states exist without matching explicit `:focus-visible` rules for primary nav, CTAs, stress links, report links, and footer links.
+- Repeated content is visually grouped but not semantically represented as lists: badges, architecture items, stress metrics, and reports.
+- Historical report cards are repetitive and do not expose status, top metric, or run context.
+- `Dashboard.astro` reads `public/reports` synchronously at build time with no guard.
+
+## Overall impression
+
+The page is already pointed in the right direction. The best redesign is not a new personality. It is the current personality with better discipline: less ambient gloss, more proof density, stronger report semantics, clearer metric provenance, and a tighter instrument-panel layout.
+
+## What's working
+
+1. **The core aesthetic fits.** Dark teal and Go cyan are correct for a Go backend benchmark site.
+2. **The information flow is understandable.** Hero, stack, performance envelope, stress results, reports, footer is the right order.
+3. **The reports are a real asset.** Archived stress-test runs are more persuasive than a decorative screenshot or generic metric row.
+
+## Priority issues
+
+### P0: Trust break from version mismatch
+
+**What:** The hero badge says Go 1.22 while metadata and project docs say Go 1.25.
+
+**Why it matters:** Benchmark audiences punish precision errors. If the language version is wrong, performance claims feel less reliable.
+
+**Fix:** Normalize the version source. Ideally derive the badge from one constant or from `go.mod`/repo metadata.
+
+**Suggested command:** `impeccable clarify`
+
+### P1: Proof hierarchy is weaker than the claims
+
+**What:** The page shows `47k+`, `<50ms`, and `99.9%`, but does not attach the values to workload, run date, commit, CI link, resource envelope, or a specific report.
+
+**Why it matters:** The site says “trust these numbers” before it proves them.
+
+**Fix:** Add a “latest validated run” strip or hero-adjacent proof rail with date, commit, workload, CPU/memory limits, report link, and CI run link.
+
+**Suggested command:** `impeccable layout`
+
+### P1: AI-template decorative effects dilute the lean Go story
+
+**What:** Gradient headline text, particles, ambient radial drift, glass nav, emoji labels, and glow effects are doing more atmosphere than evidence.
+
+**Why it matters:** The implementation sells restraint. The page should feel similarly tuned.
+
+**Fix:** Replace gradient text with solid type plus single cyan emphasis, simplify the nav into an instrument rail, remove or dramatically reduce particles, and replace emoji section labels with benchmark-native labels.
+
+**Suggested command:** `impeccable quieter`
+
+### P1: Accessibility states are incomplete
+
+**What:** Motion lacks reduced-motion handling, and hover affordances are richer than keyboard focus affordances.
+
+**Why it matters:** This is a visible quality problem for keyboard and motion-sensitive users.
+
+**Fix:** Add `prefers-reduced-motion`, explicit `:focus-visible` rings, and semantic lists for repeated groups.
+
+**Suggested command:** `impeccable harden`
+
+### P2: Historical reports are underused
+
+**What:** Report cards show only date/time. They are visually repetitive and make users click before knowing which run matters.
+
+**Why it matters:** The archive is the strongest credibility feature, but it reads like a date grid.
+
+**Fix:** Surface latest, best, and recent reports with status, top metric, and quick labels. Keep “view all reports” as the archive route.
+
+**Suggested command:** `impeccable layout`
+
+## Overhaul direction, same aesthetic
+
+**North Star:** Instrumented Restraint.
+
+Keep:
+- Dark teal base.
+- Go cyan accent.
+- Mono-forward voice.
+- Developer-native headline wit.
+- Performance and report focus.
+
+Change:
+- Make cyan functional, not atmospheric.
+- Make the latest benchmark evidence the central artifact.
+- Replace generic cards with proof modules.
+- Reduce motion to intentional state feedback.
+- Make the report archive a credibility system.
+
+## Proposed page structure
+
+1. **Instrument rail nav**
+   - Left: `rinha2-go` plus a small status dot only if it means something.
+   - Right: Docs, Reports, GitHub.
+   - Explicit focus ring and no decorative glass blur.
+
+2. **Hero with proof rail**
+   - Solid headline: “Less is More. Except Error Handling.”
+   - Shorter subcopy focused on challenge, Go stack, and constraints.
+   - CTAs: `Read docs`, `Inspect code`, secondary `Latest report`.
+   - Inline proof rail: latest run date, commit short SHA, workload, 1.5 CPU, 550MB, report link.
+
+3. **Performance envelope as a constraint diagram**
+   - Not just three number cards.
+   - Show NGINX, two API instances, Postgres, CPU/memory split, request flow.
+   - Keep it flat, technical, and compact.
+
+4. **Benchmark evidence module**
+   - Latest validated run first.
+   - Best recent run second if different.
+   - Show requests, P95, success rate, and link to report/CI.
+
+5. **Report archive preview**
+   - Three lanes: Latest, Best, Recent history.
+   - Archive link remains available.
+   - Date-only grid becomes secondary.
+
+6. **Footer with ownership and challenge context**
+   - Keep small, but include docs/source/report anchors if useful.
+
+## A/B testing plan
+
+### Test 1: Hero proof density
+
+**Hypothesis:** Visitors will trust and continue when the hero ties performance claims to evidence immediately.
+
+**A/control:** Current hero with headline, stack badges, and two CTAs.
+
+**B variant:** Add a compact proof rail under the hero: latest report date, CI run, resource limits, and commit.
+
+**C variant:** Make “Latest validated run” the right-side hero object, with metrics and report link, balancing the currently empty right side.
+
+**Primary metric:** Click-through to reports or CI from the landing page.
+
+**Recommendation:** Try C first. It uses the empty desktop hero space and improves trust without changing the aesthetic.
+
+### Test 2: Metric presentation
+
+**Hypothesis:** Constraint-aware metrics will outperform isolated big numbers for a technical audience.
+
+**A/control:** Current metric cards: `47k+`, `1.5`, `550`, plus stress metric cards.
+
+**B variant:** Merge constraints and results into a single “under 1.5 CPU / 550MB” benchmark strip.
+
+**C variant:** Replace the repeated cards with a request-flow diagram plus metrics anchored at each node.
+
+**Primary metric:** Scroll depth into reports section and clicks on documentation architecture page.
+
+**Recommendation:** Try C for the overhaul concept. It keeps the technical identity and makes the page feel custom.
+
+### Test 3: Visual restraint level
+
+**Hypothesis:** Removing decorative AI-template effects will improve perceived credibility without making the page bland.
+
+**A/control:** Current particles, ambient drift, glass nav, gradient text, emoji section labels.
+
+**B variant:** Remove gradient text and emojis, keep subtle grid and limited ambient background.
+
+**C variant:** Remove particles/glass entirely, use a static instrumentation grid and cyan only for values/focus/actions.
+
+**Primary metric:** GitHub CTA clicks and docs CTA clicks from first viewport.
+
+**Recommendation:** Try B first if risk-sensitive, C if the goal is the strongest “lean benchmark” posture.
+
+### Test 4: Report archive information scent
+
+**Hypothesis:** Report cards with summary data will get more engagement than date-only links.
+
+**A/control:** Date/time grid.
+
+**B variant:** Latest 3 reports with date, status, requests/sec, P95, and direct view links.
+
+**C variant:** Three curated tiles: Latest, Best valid run, Full archive.
+
+**Primary metric:** Report link clicks and archive clicks.
+
+**Recommendation:** Try C first. It reduces cognitive load and turns the archive into a story.
+
+### Test 5: CTA hierarchy
+
+**Hypothesis:** A report CTA in the hero will convert better than putting reports only below stress results.
+
+**A/control:** Docs primary, GitHub secondary.
+
+**B variant:** Docs primary, Latest report secondary, GitHub tertiary text link.
+
+**C variant:** Latest report primary, Docs secondary, GitHub tertiary.
+
+**Primary metric:** CTA distribution, especially report and docs clicks.
+
+**Recommendation:** Try B first. Docs remains the safe primary route while evidence becomes visible earlier.
+
+## Implementation sequence
+
+1. `impeccable clarify`: fix version mismatch and tighten performance copy.
+2. `impeccable quieter`: remove gradient text, emoji scaffolding, decorative glass/particles, and excess glow.
+3. `impeccable layout`: restructure hero proof rail, benchmark evidence, and report archive.
+4. `impeccable harden`: add reduced motion, focus-visible states, semantic lists, and report-directory fallback.
+5. `impeccable polish`: final responsive, copy, contrast, and interaction pass.
+
+## Files added for context
+
+- `PRODUCT.md`
+- `DESIGN.md`
+- `.impeccable/design.json`
+
+These capture the inferred brand strategy and current visual system so future impeccable work stays aligned with this same aesthetic.

--- a/.impeccable/design.json
+++ b/.impeccable/design.json
@@ -1,0 +1,104 @@
+{
+  "schemaVersion": 2,
+  "generatedAt": "2026-05-16T22:12:00Z",
+  "title": "Design System: rinha2-back-end-go",
+  "extensions": {
+    "colorMeta": {
+      "deep-teal-bg": {
+        "role": "neutral",
+        "displayName": "Deep Teal Console",
+        "canonical": "#0c1f1f",
+        "tonalRamp": ["oklch(15% 0.025 195)", "oklch(23% 0.03 195)", "oklch(31% 0.035 195)", "oklch(42% 0.04 195)", "oklch(55% 0.035 195)", "oklch(68% 0.025 195)", "oklch(82% 0.015 195)", "oklch(94% 0.008 195)"]
+      },
+      "teal-surface": {
+        "role": "neutral",
+        "displayName": "Teal Steel Surface",
+        "canonical": "#0f2e2e",
+        "tonalRamp": ["oklch(17% 0.03 195)", "oklch(26% 0.035 195)", "oklch(35% 0.04 195)", "oklch(46% 0.04 195)", "oklch(58% 0.035 195)", "oklch(70% 0.025 195)", "oklch(84% 0.015 195)", "oklch(95% 0.008 195)"]
+      },
+      "go-cyan": {
+        "role": "primary",
+        "displayName": "Go Instrument Cyan",
+        "canonical": "#00ADD8",
+        "tonalRamp": ["oklch(20% 0.07 220)", "oklch(30% 0.09 220)", "oklch(42% 0.11 220)", "oklch(55% 0.13 220)", "oklch(68% 0.12 220)", "oklch(78% 0.09 220)", "oklch(88% 0.05 220)", "oklch(96% 0.02 220)"]
+      }
+    },
+    "typographyMeta": {
+      "display": { "displayName": "Mono Display", "purpose": "Hero claims and dominant section statements." },
+      "body": { "displayName": "Sans Body", "purpose": "Readable technical explanation copy, paired with mono labels and metrics." },
+      "label": { "displayName": "Instrument Label", "purpose": "Badges, metric labels, navigation, and metadata." }
+    },
+    "shadows": [
+      { "name": "signal-glow", "value": "0 0 16px rgba(0, 173, 216, 0.18)", "purpose": "Active focus, hover, or one signature metric." },
+      { "name": "panel-lift", "value": "0 12px 32px rgba(0, 0, 0, 0.20)", "purpose": "Sparing hover elevation for report previews." }
+    ],
+    "motion": [
+      { "name": "state-ease", "value": "cubic-bezier(0.16, 1, 0.3, 1)", "purpose": "Fast ease-out state transitions." },
+      { "name": "reduced-motion", "value": "@media (prefers-reduced-motion: reduce)", "purpose": "Disable ambient particles, drifting backgrounds, and entrance animations." }
+    ],
+    "breakpoints": [
+      { "name": "mobile", "value": "640px" },
+      { "name": "tablet", "value": "768px" },
+      { "name": "desktop", "value": "1024px" }
+    ]
+  },
+  "components": [
+    {
+      "name": "Primary Button",
+      "kind": "button",
+      "refersTo": "button-primary",
+      "description": "Main route to docs or benchmark evidence.",
+      "html": "<button class=\"ds-btn-primary\">VIEW DOCUMENTATION</button>",
+      "css": ".ds-btn-primary { background: #00ADD8; color: #0c1f1f; border: 1px solid #00ADD8; border-radius: 4px; padding: 1rem 2rem; font-family: 'Fira Code', ui-monospace, monospace; font-weight: 700; text-transform: uppercase; letter-spacing: 0.02em; transition: transform 180ms cubic-bezier(0.16, 1, 0.3, 1), box-shadow 180ms cubic-bezier(0.16, 1, 0.3, 1); } .ds-btn-primary:hover { transform: translateY(-2px); box-shadow: 0 0 16px rgba(0, 173, 216, 0.18); } .ds-btn-primary:focus-visible { outline: 2px solid #5DC9E2; outline-offset: 3px; }"
+    },
+    {
+      "name": "Metric Card",
+      "kind": "card",
+      "refersTo": "metric-card",
+      "description": "Evidence-first metric container for benchmark claims.",
+      "html": "<article class=\"ds-metric-card\"><strong>47k+</strong><span>Target valid requests</span></article>",
+      "css": ".ds-metric-card { background: #0f2e2e; color: #e0f5f8; border: 1px solid rgba(0, 173, 216, 0.15); border-radius: 12px; padding: 1.5rem; font-family: 'Fira Code', ui-monospace, monospace; display: grid; gap: 0.35rem; } .ds-metric-card strong { color: #00ADD8; font-size: 2rem; line-height: 1; } .ds-metric-card span { color: #7dd3e8; font-size: 0.875rem; }"
+    },
+    {
+      "name": "Report Link",
+      "kind": "custom",
+      "refersTo": "report-link",
+      "description": "Historical benchmark proof artifact.",
+      "html": "<a class=\"ds-report-link\" href=\"#\"><span>2026-04-01</span><small>19:13</small></a>",
+      "css": ".ds-report-link { display: grid; gap: 0.25rem; background: #0f2e2e; color: #e0f5f8; border: 1px solid rgba(0, 173, 216, 0.15); border-radius: 8px; padding: 0.875rem 1rem; text-decoration: none; font-family: 'Fira Code', ui-monospace, monospace; transition: border-color 180ms cubic-bezier(0.16, 1, 0.3, 1), transform 180ms cubic-bezier(0.16, 1, 0.3, 1); } .ds-report-link span { color: #5DC9E2; font-size: 0.8rem; } .ds-report-link small { color: #7dd3e8; font-size: 0.75rem; } .ds-report-link:hover { border-color: #00ADD8; transform: translateY(-1px); } .ds-report-link:focus-visible { outline: 2px solid #5DC9E2; outline-offset: 3px; }"
+    }
+  ],
+  "narrative": {
+    "northStar": "Instrumented Restraint",
+    "overview": "The site should feel like a benchmark console that learned just enough art direction to be memorable. It is dark, teal, compact, and mechanical, but not theatrical. The best version keeps the terminal-performance mood while removing decorative excess, tightening proof hierarchy, and turning archived reports into a credibility asset.",
+    "keyCharacteristics": [
+      "Dark teal base with Go cyan as a precise instrumentation color.",
+      "Mono-forward typography, used with stronger hierarchy and better body readability.",
+      "Tonal layering and thin borders instead of heavy shadows or glass effects.",
+      "Metrics tied to evidence, dates, resource constraints, and report links.",
+      "Minimal motion, only when it clarifies state or directs attention."
+    ],
+    "rules": [
+      { "name": "The Instrument Rule", "body": "Cyan is an instrument reading. It marks actions, values, focus, and status. It does not decorate empty space.", "section": "colors" },
+      { "name": "The No Pure Extremes Rule", "body": "Do not use pure #000 or #fff. Keep darks and lights tinted toward the project teal.", "section": "colors" },
+      { "name": "The Mono With Purpose Rule", "body": "Monospace is allowed because this is a developer benchmark site. It still needs typographic contrast through size, weight, color, and line length.", "section": "typography" },
+      { "name": "The Flat Until Touched Rule", "body": "Surfaces rest flat. They lift only when a user interacts or when a metric needs explicit priority.", "section": "elevation" }
+    ],
+    "dos": [
+      "Do keep the Go teal/cyan identity, but use cyan only for action, proof, focus, and state.",
+      "Do tie every major performance claim to a report, CI run, or explicit workload context.",
+      "Do use semantic lists for badges, metrics, architecture items, and historical reports.",
+      "Do include prefers-reduced-motion handling for ambient and entrance animations.",
+      "Do preserve the developer-native wit when it is specific and concise."
+    ],
+    "donts": [
+      "Don't use gradient text. It is prohibited on this project.",
+      "Don't use decorative glassmorphism, floating particles, or glows as default atmosphere.",
+      "Don't repeat generic metric cards without adding context or proof.",
+      "Don't use emoji as section-label scaffolding.",
+      "Don't present vague performance claims without benchmark context.",
+      "Don't use thick side-stripe borders as accents.",
+      "Don't let terminal styling become cosplay. The code and benchmark evidence are the identity."
+    ]
+  }
+}

--- a/DESIGN.md
+++ b/DESIGN.md
@@ -1,0 +1,173 @@
+---
+name: rinha2-back-end-go
+description: Lean Go benchmark landing page for Rinha de Backend 2024/Q1.
+colors:
+  deep-teal-bg: "#0c1f1f"
+  teal-surface: "#0f2e2e"
+  go-cyan: "#00ADD8"
+  go-cyan-light: "#5DC9E2"
+  dark-cyan: "#0a3040"
+  text-primary: "#e0f5f8"
+  text-secondary: "#7dd3e8"
+  text-muted: "#2e7a90"
+typography:
+  display:
+    fontFamily: "Fira Code, ui-monospace, SFMono-Regular, Menlo, Monaco, Consolas, monospace"
+    fontSize: "clamp(2.5rem, 7vw, 3.5rem)"
+    fontWeight: 700
+    lineHeight: 1.1
+  body:
+    fontFamily: "Inter, ui-sans-serif, system-ui, -apple-system, BlinkMacSystemFont, 'Segoe UI', sans-serif"
+    fontSize: "1rem"
+    fontWeight: 400
+    lineHeight: 1.6
+  label:
+    fontFamily: "Fira Code, ui-monospace, SFMono-Regular, Menlo, Monaco, Consolas, monospace"
+    fontSize: "0.8rem"
+    fontWeight: 600
+    letterSpacing: "0.05em"
+rounded:
+  sm: "4px"
+  md: "8px"
+  lg: "12px"
+spacing:
+  xs: "0.5rem"
+  sm: "0.75rem"
+  md: "1rem"
+  lg: "1.5rem"
+  xl: "2rem"
+  section: "5rem"
+components:
+  button-primary:
+    backgroundColor: "{colors.go-cyan}"
+    textColor: "{colors.deep-teal-bg}"
+    rounded: "{rounded.sm}"
+    padding: "1rem 2rem"
+  button-outline:
+    backgroundColor: "transparent"
+    textColor: "{colors.go-cyan}"
+    rounded: "{rounded.sm}"
+    padding: "1rem 2rem"
+  metric-card:
+    backgroundColor: "{colors.teal-surface}"
+    textColor: "{colors.text-primary}"
+    rounded: "{rounded.lg}"
+    padding: "1.5rem"
+---
+
+# Design System: rinha2-back-end-go
+
+## 1. Overview
+
+**Creative North Star: "Instrumented Restraint"**
+
+The site should feel like a benchmark console that learned just enough art direction to be memorable. It is dark, teal, compact, and mechanical, but not theatrical. The current Go cyan identity is worth preserving because it ties the surface to the implementation language and makes the project instantly recognizable.
+
+This is a brand surface for a technical project, so the design itself must communicate competence. The page should look fast because it is measured, not because it glows. The best version keeps the terminal-performance mood while removing decorative excess, tightening proof hierarchy, and turning archived reports into a credibility asset.
+
+**Key Characteristics:**
+- Dark teal base with Go cyan as a precise instrumentation color.
+- Mono-forward typography, used with stronger hierarchy and better body readability.
+- Tonal layering and thin borders instead of heavy shadows or glass effects.
+- Metrics tied to evidence, dates, resource constraints, and report links.
+- Minimal motion, only when it clarifies state or directs attention.
+
+## 2. Colors
+
+The palette is Go cyan on deep engineered teal. It should stay narrow, but the accent must behave like an instrument reading, not a decorative glow.
+
+### Primary
+- **Go Instrument Cyan**: The primary action and data-accent color. Use for primary buttons, important metric values, focus rings, and active states.
+- **Light Cyan Signal**: Secondary accent for hover states, badge text, and supporting highlights.
+
+### Neutral
+- **Deep Teal Console**: The page background. Never use pure black as the base.
+- **Teal Steel Surface**: Section panels, metric containers, and report tiles.
+- **Dark Cyan Structural**: Subtle separators, underlays, and low-emphasis borders.
+- **Mist Text**: Primary readable text on dark surfaces.
+- **Muted Cyan Text**: Secondary text, captions, and labels.
+
+### Named Rules
+
+**The Instrument Rule.** Cyan is an instrument reading. It marks actions, values, focus, and status. It does not decorate empty space.
+
+**The No Pure Extremes Rule.** Do not use pure `#000` or `#fff`. Keep darks and lights tinted toward the project teal.
+
+## 3. Typography
+
+**Display Font:** Fira Code with system monospace fallbacks
+**Body Font:** Inter with system sans-serif fallbacks
+**Label/Mono Font:** Fira Code with system monospace fallbacks
+
+**Character:** The current mono-forward voice fits the project, but long-form readability improves when body copy uses a quiet sans while headings, labels, metrics, and controls retain the instrument-console mono voice.
+
+### Hierarchy
+- **Display** (700, `clamp(2.5rem, 7vw, 3.5rem)`, 1.1): Hero headline and one dominant idea per fold.
+- **Headline** (700, `clamp(1.75rem, 4vw, 2.5rem)`, 1.2): Major sections such as performance envelope and stress results.
+- **Title** (600, `1.25rem`, 1.3): Report groups and component-level headings.
+- **Body** (400, `1rem`, 1.6): Explanatory copy. Keep paragraphs under 65 to 75 characters.
+- **Label** (600, `0.75rem` to `0.875rem`, tracked): Badges, metric labels, nav items, and report metadata.
+
+### Named Rules
+
+**The Mono With Purpose Rule.** Monospace is allowed because this is a developer benchmark site. It still needs typographic contrast through size, weight, color, and line length.
+
+## 4. Elevation
+
+The system should be mostly flat. Depth comes from tonal surfaces, thin borders, grid texture, and state changes. Shadows and glows are allowed only as state feedback or data emphasis, not as a permanent atmospheric layer.
+
+### Shadow Vocabulary
+- **Signal Glow** (`0 0 16px rgba(0, 173, 216, 0.18)`): Use only on active focus, hover, or a single signature metric.
+- **Panel Lift** (`0 12px 32px rgba(0, 0, 0, 0.20)`): Use sparingly for elevated report previews or hover states.
+
+### Named Rules
+
+**The Flat Until Touched Rule.** Surfaces rest flat. They lift only when a user interacts or when a metric needs explicit priority.
+
+## 5. Components
+
+### Buttons
+- **Shape:** Sharp technical corners with slight rounding (4px).
+- **Primary:** Go cyan fill with deep teal text, uppercase mono label, generous horizontal padding.
+- **Hover / Focus:** Shift tone and add a visible cyan focus ring. Keyboard focus must be as obvious as hover.
+- **Secondary / Ghost:** Transparent surface, cyan border, cyan text. Use for GitHub or secondary documentation routes.
+
+### Chips
+- **Style:** Compact teal surface, cyan text, subtle cyan border.
+- **State:** Static tech badges should not look clickable. If a chip becomes interactive, add focus and hover states.
+
+### Cards / Containers
+- **Corner Style:** Moderate rounding (12px) for major panels, smaller rounding for report links.
+- **Background:** Teal steel surfaces on deep teal console background.
+- **Shadow Strategy:** Flat at rest. Use borders and tonal contrast first.
+- **Border:** Thin cyan-tinted borders. No thick side stripes.
+- **Internal Padding:** 1.5rem to 2rem for cards; larger rhythm only around major sections.
+
+### Inputs / Fields
+- **Style:** Dark teal fill, cyan border on focus, mono text.
+- **Focus:** Visible outline or ring. Never remove outlines without replacing them.
+- **Error / Disabled:** Use text and icon/status affordances, not color alone.
+
+### Navigation
+- Sticky top navigation may stay, but it should feel like a slim instrument rail, not a glass panel. Use a tinted opaque or near-opaque background, thin border, clear focus states, and short labels.
+
+### Reports
+- Historical report links are proof artifacts, not decorative tiles. Each report item should expose date, time, and ideally a small status or metric summary when available.
+
+## 6. Do's and Don'ts
+
+### Do:
+- **Do** keep the Go teal/cyan identity, but use cyan only for action, proof, focus, and state.
+- **Do** tie every major performance claim to a report, CI run, or explicit workload context.
+- **Do** use semantic lists for badges, metrics, architecture items, and historical reports.
+- **Do** include `prefers-reduced-motion` handling for ambient and entrance animations.
+- **Do** preserve the developer-native wit when it is specific and concise.
+
+### Don't:
+- **Don't** use gradient text. It is prohibited on this project.
+- **Don't** use decorative glassmorphism, floating particles, or glows as default atmosphere.
+- **Don't** repeat generic metric cards without adding context or proof.
+- **Don't** use emoji as section-label scaffolding.
+- **Don't** present vague performance claims without benchmark context.
+- **Don't** use thick side-stripe borders as accents.
+- **Don't** let terminal styling become cosplay. The code and benchmark evidence are the identity.

--- a/PRODUCT.md
+++ b/PRODUCT.md
@@ -1,0 +1,33 @@
+# Product
+
+## Register
+
+brand
+
+## Users
+
+Backend engineers, challenge reviewers, and open-source maintainers evaluating a compact Go implementation of Rinha de Backend 2024/Q1. They arrive with a technical mindset: they want to understand the architecture quickly, trust the benchmark claims, inspect the implementation, and jump to documentation, reports, or source code without friction.
+
+## Product Purpose
+
+This site presents `rinha2-back-end-go` as a lean, high-performance banking API implementation built under strict challenge constraints. Success means visitors immediately understand what was built, why the Go implementation is credible, which performance evidence supports it, and where to inspect the code, documentation, CI runs, and archived stress-test reports.
+
+## Brand Personality
+
+Lean, mechanical, precise. The voice should feel like a well-tuned benchmark harness: terse, data-backed, quietly confident, and allergic to inflated marketing claims. Humor is welcome when it is developer-native and specific, as in “Less is More. Except Error Handling.”
+
+## Anti-references
+
+Avoid generic SaaS landing-page gloss, AI-generated neon dashboard clichés, decorative glassmorphism, gradient text, vague “extreme performance” claims without evidence, emoji-led section labels, and terminal cosplay that hides the actual engineering proof. The site should not feel like a crypto dashboard, an AI tool template, or a portfolio theme with benchmark words pasted into it.
+
+## Design Principles
+
+1. **Proof before polish.** Metrics, constraints, report links, and architecture facts should carry the page. Decorative effects must never compete with evidence.
+2. **Practice the implementation’s restraint.** The visual system should mirror the code posture: minimal, purposeful, fast, and direct.
+3. **Make claims traceable.** Every major performance number should connect to a report, CI run, workload, or context.
+4. **Keep the Go identity, not the cliché.** Teal/cyan can remain the signature, but it should feel like engineered instrumentation, not a generic neon tech theme.
+5. **Reduce cognitive ceremony.** Visitors should not decode the page. Docs, GitHub, current benchmark evidence, and historical reports must be obvious.
+
+## Accessibility & Inclusion
+
+Target WCAG AA for text contrast, focus visibility, semantic structure, and keyboard access. Respect `prefers-reduced-motion`, especially because the current aesthetic uses ambient and entrance motion. Use lists and landmarks for repeated content. Keep body copy readable despite the mono-forward visual identity.

--- a/docs/src/components/home/Dashboard.astro
+++ b/docs/src/components/home/Dashboard.astro
@@ -3,93 +3,147 @@ import fs from 'node:fs';
 import path from 'node:path';
 
 const stressTestMetrics = [
-  { value: '47k+', label: 'Requests/Second' },
-  { value: '<50ms', label: 'P95 Latency' },
-  { value: '99.9%', label: 'Success Rate' }
+  { value: '47k+', label: 'target valid requests', context: 'challenge scoring target' },
+  { value: '<50ms', label: 'P95 latency', context: 'latest published target' },
+  { value: '99.9%', label: 'success rate', context: 'expected valid-run floor' },
+];
+
+const architecture = [
+  { name: 'NGINX', detail: 'least_conn load balancer on :9999' },
+  { name: 'API x2', detail: 'two Go/chi instances behind the proxy' },
+  { name: 'PostgreSQL', detail: 'stored procedures keep balance updates atomic' },
+  { name: 'k6', detail: 'archived CI stress-test reports' },
 ];
 
 const reportsDir = path.join(process.cwd(), 'public/reports');
-const allReports = fs.readdirSync(reportsDir)
-  .filter(f => f.endsWith('.html'))
-  .sort()
-  .reverse();
+const allReports = fs.existsSync(reportsDir)
+  ? fs.readdirSync(reportsDir).filter(f => f.endsWith('.html')).sort().reverse()
+  : [];
 
 function parseReportMeta(filename: string) {
   const match = filename.match(/(\d{4})(\d{2})(\d{2})(\d{2})(\d{2})(\d{2})/);
-  if (!match) return { date: filename, time: '' };
+  if (!match) return { date: filename, time: '', label: 'archived run' };
   const [, year, month, day, hour, minute] = match;
   return {
     date: `${year}-${month}-${day}`,
     time: `${hour}:${minute}`,
+    label: 'k6 stress report',
   };
 }
 
-const recentReports = allReports.slice(0, 8).map(file => ({
-  file,
-  ...parseReportMeta(file),
-}));
+const latestReport = allReports[0] ? { file: allReports[0], ...parseReportMeta(allReports[0]) } : null;
+const recentReports = allReports.slice(0, 6).map(file => ({ file, ...parseReportMeta(file) }));
+const curatedReports = [
+  latestReport && { title: 'Latest archived run', ...latestReport },
+  allReports[1] && { title: 'Previous run', file: allReports[1], ...parseReportMeta(allReports[1]) },
+  allReports[2] && { title: 'Recent baseline', file: allReports[2], ...parseReportMeta(allReports[2]) },
+].filter(Boolean);
 ---
 
-<section class="specs">
-  <h2>Performance Envelope</h2>
-  <div class="grid-3">
-    <div class="spec-item">
-      <span class="spec-val">47k+</span>
-      <span class="spec-label">Target Valid Requests</span>
-    </div>
-    <div class="spec-item">
-      <span class="spec-val">1.5</span>
-      <span class="spec-label">Max CPU Cores (Total)</span>
-    </div>
-    <div class="spec-item">
-      <span class="spec-val">550</span>
-      <span class="spec-label">Max Memory (MB)</span>
-    </div>
+<section class="specs" aria-labelledby="envelope-title">
+  <div class="section-heading">
+    <p class="eyebrow">Performance envelope</p>
+    <h2 id="envelope-title">The constraint is the architecture.</h2>
+    <p>
+      The implementation is intentionally small: two Go API instances, one NGINX balancer, and one PostgreSQL database sharing the challenge’s total CPU and memory budget.
+    </p>
   </div>
 
-  <div class="arch-list">
-    <div>2x API Instances</div>
-    <div>1x Nginx LB</div>
-    <div>1x Postgres Database</div>
-    <div>Docker Compose Orchestration</div>
-  </div>
+  <ul class="grid-3" aria-label="Challenge constraints">
+    <li class="spec-item">
+      <span class="spec-val">47k+</span>
+      <span class="spec-label">target valid requests</span>
+    </li>
+    <li class="spec-item">
+      <span class="spec-val">1.5</span>
+      <span class="spec-label">max CPU cores total</span>
+    </li>
+    <li class="spec-item">
+      <span class="spec-val">550</span>
+      <span class="spec-label">max memory in MB</span>
+    </li>
+  </ul>
+
+  <ol class="arch-list" aria-label="Request flow">
+    {architecture.map(item => (
+      <li>
+        <strong>{item.name}</strong>
+        <span>{item.detail}</span>
+      </li>
+    ))}
+  </ol>
 </section>
 
-<section class="stress-tests">
-  <h3>⚡ Stress Test Results</h3>
-  <p class="stress-intro">
-    Validated under extreme load conditions using k6. The system maintains stable performance
-    even when processing thousands of concurrent banking transactions.
-  </p>
-
-  <div class="stress-metrics">
-    {stressTestMetrics.map(metric => (
-      <div class="stress-metric">
-        <span class="metric-value">{metric.value}</span>
-        <span class="metric-label">{metric.label}</span>
-      </div>
-    ))}
+<section class="stress-tests" aria-labelledby="stress-title">
+  <div class="section-heading centered">
+    <p class="eyebrow">Benchmark evidence</p>
+    <h3 id="stress-title">Stress-test results stay attached to reports.</h3>
+    <p class="stress-intro">
+      The headline numbers are treated as evidence, not ornament. Use the archived reports and CI workflow to inspect each run instead of trusting a static badge.
+    </p>
   </div>
 
+  <ul class="stress-metrics" aria-label="Stress-test headline metrics">
+    {stressTestMetrics.map(metric => (
+      <li class="stress-metric">
+        <span class="metric-value">{metric.value}</span>
+        <span class="metric-label">{metric.label}</span>
+        <small>{metric.context}</small>
+      </li>
+    ))}
+  </ul>
+
   <div class="stress-links">
+    {latestReport && (
+      <a href={`./reports/${latestReport.file}`} class="stress-link">
+        Latest report: {latestReport.date} {latestReport.time}
+      </a>
+    )}
     <a href="https://github.com/jonathanperis/rinha2-back-end-go/actions/workflows/main-release.yml" class="stress-link" target="_blank" rel="noopener noreferrer">
-      <span>📊</span> View CI/CD Stress Tests
+      CI stress tests
     </a>
-    <a href="./docs/" class="stress-link">
-      <span>📖</span> Documentation
+    <a href="./docs/performance/" class="stress-link">
+      Performance notes
     </a>
   </div>
 
   <div class="reports-section">
-    <h4>📈 Historical Reports</h4>
-    <div class="reports-grid">
-      {recentReports.map(report => (
-        <a href={`./reports/${report.file}`} class="report-link">
-          <span class="report-date">{report.date}</span>
-          <span class="report-time">{report.time}</span>
-        </a>
-      ))}
+    <div class="section-heading compact centered">
+      <p class="eyebrow">Report archive</p>
+      <h4>Recent proof artifacts</h4>
     </div>
-    <p class="reports-note">{allReports.length} stress test runs archived • <a href="./reports/">View all reports →</a></p>
+
+    {curatedReports.length > 0 ? (
+      <ul class="reports-featured" aria-label="Featured stress-test reports">
+        {curatedReports.map(report => (
+          <li>
+            <a href={`./reports/${report.file}`} class="report-feature">
+              <span class="report-title">{report.title}</span>
+              <strong>{report.date}</strong>
+              <small>{report.time} · {report.label}</small>
+            </a>
+          </li>
+        ))}
+      </ul>
+    ) : (
+      <p class="empty-reports">No archived stress-test reports were found in this build.</p>
+    )}
+
+    {recentReports.length > 0 && (
+      <ul class="reports-grid" aria-label="Recent stress-test reports">
+        {recentReports.map(report => (
+          <li>
+            <a href={`./reports/${report.file}`} class="report-link">
+              <span class="report-date">{report.date}</span>
+              <span class="report-time">{report.time}</span>
+            </a>
+          </li>
+        ))}
+      </ul>
+    )}
+
+    <p class="reports-note">
+      {allReports.length} stress test runs archived · <a href="./reports/">View all reports</a>
+    </p>
   </div>
 </section>

--- a/docs/src/components/home/Hero.astro
+++ b/docs/src/components/home/Hero.astro
@@ -1,21 +1,47 @@
 ---
+const stack = ['Go 1.25', 'chi/v5', 'pgx/v5', 'PostgreSQL', 'NGINX'];
+
+const proofItems = [
+  { label: 'Challenge', value: 'Rinha 2024/Q1' },
+  { label: 'Resource cap', value: '1.5 CPU / 550MB' },
+  { label: 'Shape', value: '2 APIs + LB + Postgres' },
+];
 ---
 
-<section class="hero">
-  <h1>Less is More.<br><span>Except Error Handling.</span></h1>
-  <p class="tagline">
-    Go Implementation of Rinha de Backend 2024/Q1. Delivering extreme throughput and low latency under strict resource constraints for a fictional bank API.
-  </p>
+<section class="hero" aria-labelledby="hero-title">
+  <div class="hero-copy">
+    <p class="eyebrow">Go banking API under contest constraints</p>
+    <h1 id="hero-title">
+      Less is More.
+      <span>Except Error Handling.</span>
+    </h1>
+    <p class="tagline">
+      A compact Go implementation of Rinha de Backend 2024/Q1, tuned for concurrent banking transactions with chi, pgx, PostgreSQL stored procedures, and NGINX load balancing.
+    </p>
 
-  <div class="badges">
-    <span class="badge">Go 1.22</span>
-    <span class="badge">Nginx</span>
-    <span class="badge">PostgreSQL</span>
-    <span class="badge">pgxpool</span>
+    <ul class="badges" aria-label="Technology stack">
+      {stack.map(item => <li class="badge">{item}</li>)}
+    </ul>
+
+    <div class="ctas" aria-label="Primary links">
+      <a href="./docs/" class="btn btn-primary">Read docs</a>
+      <a href="./reports/" class="btn btn-outline">Latest reports</a>
+      <a href="https://github.com/jonathanperis/rinha2-back-end-go" class="btn btn-ghost">Inspect code</a>
+    </div>
   </div>
 
-  <div class="ctas">
-    <a href="./docs/" class="btn btn-primary">View Documentation &rarr;</a>
-    <a href="https://github.com/jonathanperis/rinha2-back-end-go" class="btn btn-outline">View on GitHub &rarr;</a>
-  </div>
+  <aside class="proof-rail" aria-label="Benchmark context">
+    <p class="proof-kicker">Validated envelope</p>
+    <ul>
+      {proofItems.map(item => (
+        <li>
+          <span>{item.label}</span>
+          <strong>{item.value}</strong>
+        </li>
+      ))}
+    </ul>
+    <a href="https://github.com/jonathanperis/rinha2-back-end-go/actions/workflows/main-release.yml" class="proof-link">
+      CI stress-test workflow
+    </a>
+  </aside>
 </section>

--- a/docs/src/components/home/Navbar.astro
+++ b/docs/src/components/home/Navbar.astro
@@ -6,10 +6,11 @@ interface Props {
 const { title = 'rinha2-go' } = Astro.props;
 ---
 
-<nav>
-  <div class="logo">{title}</div>
+<nav aria-label="Primary navigation">
+  <a class="logo" href="./" aria-label="rinha2-go home">{title}</a>
   <div class="nav-links">
-    <a href="https://github.com/jonathanperis/rinha2-back-end-go">GitHub</a>
     <a href="./docs/">Docs</a>
+    <a href="./reports/">Reports</a>
+    <a href="https://github.com/jonathanperis/rinha2-back-end-go">GitHub</a>
   </div>
 </nav>

--- a/docs/src/layouts/BaseLayout.astro
+++ b/docs/src/layouts/BaseLayout.astro
@@ -66,17 +66,6 @@ const jsonLd = {
     <Analytics />
   </head>
   <body>
-    <div class="particles">
-      <div class="particle"></div>
-      <div class="particle"></div>
-      <div class="particle"></div>
-      <div class="particle"></div>
-      <div class="particle"></div>
-      <div class="particle"></div>
-    </div>
-
-    <div class="data-streams"></div>
-
     <slot />
   </body>
 </html>

--- a/docs/src/styles/globals.css
+++ b/docs/src/styles/globals.css
@@ -1,26 +1,20 @@
 @import "tailwindcss";
 
 :root {
-  /* Go / Teal palette */
   --bg-deep: #0c1f1f;
   --bg-metal: #0f2e2e;
-  --rust-orange: #00ADD8;   /* alias: go teal */
-  --rust-bright: #5DC9E2;   /* alias: go light cyan */
-  --rust-dark: #0a3040;     /* alias: go dark teal */
+  --surface: #132a2a;
+  --surface-strong: #163636;
+  --rust-orange: #00ADD8;
+  --rust-bright: #5DC9E2;
+  --rust-dark: #0a3040;
   --text-main: #e0f5f8;
   --text-muted: #7dd3e8;
-
-  /* Enhanced palette */
-  --enhanced-accent: #00ADD8;
-  --enhanced-accent-dim: rgba(0, 173, 216, 0.15);
-  --enhanced-accent-glow: rgba(0, 173, 216, 0.08);
-  --enhanced-bg-deep: #0c1f1f;
-  --enhanced-bg-surface: #0f2e2e;
-  --enhanced-text-primary: #e0f5f8;
-  --enhanced-text-secondary: #7dd3e8;
-  --enhanced-text-muted: #2e7a90;
-  --enhanced-border-subtle: rgba(0, 173, 216, 0.08);
-  --enhanced-border-medium: rgba(0, 173, 216, 0.15);
+  --text-soft: #a8dde8;
+  --text-dim: #6cb8c8;
+  --border-subtle: rgba(0, 173, 216, 0.12);
+  --border-medium: rgba(0, 173, 216, 0.22);
+  --focus-ring: 0 0 0 3px rgba(93, 201, 226, 0.28);
 }
 
 * {
@@ -31,107 +25,39 @@
 
 html {
   scroll-behavior: smooth;
-  scrollbar-color: #00ADD8 #0f2e2e;
+  scrollbar-color: var(--rust-orange) var(--bg-metal);
   scrollbar-width: thin;
 }
 
-::-webkit-scrollbar {
-  width: 6px;
-  height: 6px;
-}
-
-::-webkit-scrollbar-track {
-  background: #0c1f1f;
-  border-left: 1px solid rgba(10, 48, 64, 0.5);
-}
-
-::-webkit-scrollbar-thumb {
-  background: var(--rust-orange);
-  border-radius: 3px;
-  transition: background 0.2s;
-}
-
-::-webkit-scrollbar-thumb:hover {
-  background: #5DC9E2;
-}
-
-::-webkit-scrollbar-corner {
-  background: #0c1f1f;
-}
+::-webkit-scrollbar { width: 6px; height: 6px; }
+::-webkit-scrollbar-track { background: var(--bg-deep); }
+::-webkit-scrollbar-thumb { background: var(--rust-orange); border-radius: 3px; }
+::-webkit-scrollbar-thumb:hover { background: var(--rust-bright); }
+::-webkit-scrollbar-corner { background: var(--bg-deep); }
 
 body {
-  font-family: 'Fira Code', monospace;
-  background-color: var(--bg-deep);
+  font-family: 'Inter', ui-sans-serif, system-ui, -apple-system, BlinkMacSystemFont, 'Segoe UI', sans-serif;
+  background:
+    linear-gradient(90deg, rgba(93, 201, 226, 0.045) 1px, transparent 1px),
+    linear-gradient(180deg, rgba(93, 201, 226, 0.035) 1px, transparent 1px),
+    radial-gradient(circle at 82% 10%, rgba(0, 173, 216, 0.08), transparent 32rem),
+    var(--bg-deep);
+  background-size: 44px 44px, 44px 44px, auto, auto;
   color: var(--text-main);
   line-height: 1.6;
   min-height: 100vh;
   display: flex;
   flex-direction: column;
   overflow-x: clip;
-  position: relative;
 }
 
-/* Data Streams Background */
-.data-streams {
-  position: fixed;
-  top: 0;
-  left: 0;
-  width: 100vw;
-  height: 100vh;
-  z-index: -1;
-  pointer-events: none;
-  opacity: 0.1;
-  background: linear-gradient(90deg, #0c1f1f 21px, transparent 1%) center, linear-gradient(#0c1f1f 21px, transparent 1%) center, #5DC9E2;
-  background-size: 22px 22px;
-}
-
-/* Floating Particles */
-.particles {
-  position: fixed;
-  inset: 0;
-  z-index: -1;
-  pointer-events: none;
-}
-
-.particle {
-  position: absolute;
-  width: 2px;
-  height: 2px;
-  background: #00ADD8;
-  border-radius: 50%;
-  opacity: 0;
-  animation: particle-float linear infinite;
-}
-
-.particle:nth-child(1) { left: 10%; animation-duration: 15s; animation-delay: 0s; }
-.particle:nth-child(2) { left: 25%; animation-duration: 18s; animation-delay: -3s; }
-.particle:nth-child(3) { left: 40%; animation-duration: 12s; animation-delay: -6s; }
-.particle:nth-child(4) { left: 55%; animation-duration: 20s; animation-delay: -9s; }
-.particle:nth-child(5) { left: 70%; animation-duration: 16s; animation-delay: -12s; }
-.particle:nth-child(6) { left: 85%; animation-duration: 14s; animation-delay: -4s; }
-
-@keyframes particle-float {
-  0% { transform: translateY(100vh) scale(0); opacity: 0; }
-  10% { opacity: 0.6; }
-  90% { opacity: 0.6; }
-  100% { transform: translateY(-10vh) scale(1); opacity: 0; }
-}
-
-/* Ambient Background */
-body::before {
-  content: '';
-  position: fixed;
-  inset: 0;
-  background: radial-gradient(ellipse at 30% 20%, rgba(0, 173, 216, 0.08) 0%, transparent 50%),
-              radial-gradient(ellipse at 70% 80%, rgba(93, 201, 226, 0.06) 0%, transparent 50%);
-  pointer-events: none;
-  z-index: -2;
-  animation: ambient-drift 20s ease-in-out infinite alternate;
-}
-
-@keyframes ambient-drift {
-  0% { transform: translate(0, 0) scale(1); }
-  100% { transform: translate(-5%, 3%) scale(1.05); }
+ul, ol { list-style: none; }
+a { color: inherit; }
+a:focus-visible,
+button:focus-visible {
+  outline: 2px solid var(--rust-bright);
+  outline-offset: 4px;
+  box-shadow: var(--focus-ring);
 }
 
 /* Nav */
@@ -139,461 +65,465 @@ nav {
   display: flex;
   justify-content: space-between;
   align-items: center;
-  padding: 1.5rem 3rem;
-  border-bottom: 1px solid #1c4040;
-  background: rgba(12, 31, 31, 0.8);
-  backdrop-filter: blur(20px);
-  -webkit-backdrop-filter: blur(20px);
+  gap: 1.5rem;
+  padding: 1.15rem clamp(1.25rem, 4vw, 3rem);
+  border-bottom: 1px solid var(--border-subtle);
+  background: rgba(12, 31, 31, 0.96);
   position: sticky;
   top: 0;
   z-index: 100;
-  transition: all 0.3s;
-}
-
-nav:hover {
-  background: rgba(12, 31, 31, 0.95);
 }
 
 .logo {
+  font-family: 'Fira Code', ui-monospace, SFMono-Regular, Menlo, Monaco, Consolas, monospace;
   font-weight: 700;
-  color: var(--rust-orange);
-  font-size: 1.2rem;
-  font-family: 'Fira Code', monospace;
+  color: var(--rust-bright);
+  font-size: 1rem;
+  text-decoration: none;
   display: flex;
   align-items: center;
-  gap: 0.5rem;
-  transition: all 0.3s;
+  gap: 0.65rem;
 }
 
 .logo::before {
   content: '';
-  display: inline-block;
-  width: 8px;
-  height: 8px;
-  background: #00ADD8;
+  width: 0.6rem;
+  height: 0.6rem;
+  background: var(--rust-orange);
   border-radius: 2px;
-  box-shadow: 0 0 8px #00ADD8;
+  box-shadow: 0 0 0 4px rgba(0, 173, 216, 0.08);
 }
 
 .nav-links {
   display: flex;
-  gap: 2rem;
+  gap: clamp(0.9rem, 2vw, 2rem);
+  align-items: center;
 }
 
 .nav-links a {
+  font-family: 'Fira Code', ui-monospace, SFMono-Regular, Menlo, Monaco, Consolas, monospace;
   color: var(--text-muted);
   text-decoration: none;
-  font-weight: 500;
-  transition: color 0.3s;
+  font-weight: 600;
   text-transform: uppercase;
-  font-size: 0.875rem;
-  position: relative;
-}
-
-.nav-links a::after {
-  content: '';
-  position: absolute;
-  bottom: -4px;
-  left: 0;
-  width: 0;
-  height: 1px;
-  background: #00ADD8;
-  transition: width 0.3s ease;
+  font-size: 0.82rem;
+  letter-spacing: 0.06em;
+  padding-block: 0.2rem;
+  border-bottom: 1px solid transparent;
+  transition: color 160ms ease-out, border-color 160ms ease-out;
 }
 
 .nav-links a:hover {
-  color: var(--rust-bright);
+  color: var(--text-main);
+  border-color: var(--rust-orange);
 }
 
-.nav-links a:hover::after {
-  width: 100%;
-}
-
-/* Main */
 main {
   flex: 1;
-  padding: 5rem 2rem;
-  max-width: 1000px;
+  padding: clamp(3rem, 6vw, 5rem) clamp(1.25rem, 4vw, 2rem) clamp(2rem, 4vw, 3rem);
+  max-width: 1180px;
   margin: 0 auto;
   width: 100%;
 }
 
+/* Shared */
+.eyebrow {
+  font-family: 'Fira Code', ui-monospace, SFMono-Regular, Menlo, Monaco, Consolas, monospace;
+  color: var(--rust-bright);
+  font-size: 0.78rem;
+  font-weight: 700;
+  letter-spacing: 0.12em;
+  text-transform: uppercase;
+  margin-bottom: 0.8rem;
+}
+
+.section-heading {
+  max-width: 780px;
+  margin-bottom: 2rem;
+}
+
+.section-heading.centered {
+  text-align: center;
+  margin-inline: auto;
+}
+
+.section-heading.compact { margin-bottom: 1.25rem; }
+.section-heading h2,
+.section-heading h3,
+.section-heading h4 {
+  color: var(--text-main);
+  line-height: 1.18;
+  letter-spacing: -0.03em;
+  margin-bottom: 0.85rem;
+}
+.section-heading h2 { font-size: clamp(1.8rem, 4vw, 2.55rem); }
+.section-heading h3 { font-size: clamp(1.65rem, 3.5vw, 2.15rem); }
+.section-heading h4 { font-size: clamp(1.25rem, 2.5vw, 1.55rem); }
+.section-heading p:not(.eyebrow) { color: var(--text-soft); max-width: 72ch; }
+
 /* Hero */
 .hero {
-  margin-bottom: 5rem;
-  animation: fade-up 0.8s ease-out both;
-  position: relative;
+  display: grid;
+  grid-template-columns: minmax(0, 1fr) minmax(280px, 390px);
+  gap: clamp(2rem, 6vw, 4rem);
+  align-items: center;
+  margin-bottom: clamp(2.75rem, 6vw, 4.25rem);
+  animation: fade-up 650ms cubic-bezier(0.16, 1, 0.3, 1) both;
 }
 
 .hero h1 {
-  font-size: 3.5rem;
+  font-family: 'Fira Code', ui-monospace, SFMono-Regular, Menlo, Monaco, Consolas, monospace;
+  font-size: clamp(2.6rem, 6.4vw, 4.85rem);
   font-weight: 700;
-  line-height: 1.1;
-  margin-bottom: 1.5rem;
-  font-family: 'Fira Code', monospace;
-  background: linear-gradient(135deg, #e8f4f8 0%, #00ADD8 100%);
-  -webkit-background-clip: text;
-  -webkit-text-fill-color: transparent;
-  background-clip: text;
+  line-height: 0.98;
+  margin-bottom: 1.35rem;
+  letter-spacing: -0.07em;
+  color: var(--text-main);
+  max-width: 13.5ch;
 }
 
 .hero h1 span {
+  display: block;
   color: var(--rust-orange);
-  -webkit-text-fill-color: var(--rust-orange);
 }
 
 .tagline {
-  font-size: 1.25rem;
-  color: var(--text-muted);
-  margin-bottom: 3rem;
-  max-width: 700px;
-  font-family: 'Fira Code', monospace;
-  line-height: 1.5;
+  font-size: clamp(1rem, 2vw, 1.16rem);
+  color: var(--text-soft);
+  margin-bottom: 2rem;
+  max-width: 68ch;
+  line-height: 1.7;
 }
 
 @keyframes fade-up {
-  from { opacity: 0; transform: translateY(30px); }
+  from { opacity: 0; transform: translateY(18px); }
   to { opacity: 1; transform: translateY(0); }
 }
 
-/* Badges */
 .badges {
   display: flex;
-  gap: 0.75rem;
-  margin-bottom: 3rem;
+  gap: 0.65rem;
+  margin-bottom: 2rem;
   flex-wrap: wrap;
 }
 
 .badge {
-  padding: 0.25rem 0.75rem;
+  font-family: 'Fira Code', ui-monospace, SFMono-Regular, Menlo, Monaco, Consolas, monospace;
+  padding: 0.28rem 0.7rem;
   border-radius: 999px;
-  background: #132a2a;
-  border: 1px solid #1c4040;
+  background: var(--surface);
+  border: 1px solid var(--border-subtle);
   color: var(--rust-bright);
-  font-size: 0.8rem;
-  font-weight: 600;
-  font-family: 'Fira Code', monospace;
-  transition: all 0.2s;
+  font-size: 0.78rem;
+  font-weight: 650;
 }
 
-.badge:hover {
-  border-color: #00ADD8;
-  color: #5DC9E2;
-  background: rgba(0, 173, 216, 0.15);
-}
-
-/* CTAs */
 .ctas {
   display: flex;
-  gap: 1rem;
+  flex-wrap: wrap;
+  gap: 0.8rem;
 }
 
 .btn {
+  font-family: 'Fira Code', ui-monospace, SFMono-Regular, Menlo, Monaco, Consolas, monospace;
   display: inline-flex;
   align-items: center;
   justify-content: center;
-  padding: 0.875rem 2rem;
+  min-height: 2.9rem;
+  padding: 0.82rem 1.25rem;
   text-decoration: none;
-  font-weight: 600;
+  font-weight: 700;
   border-radius: 4px;
-  transition: all 0.2s;
-  font-family: 'Fira Code', monospace;
+  border: 1px solid transparent;
+  transition: transform 160ms cubic-bezier(0.16, 1, 0.3, 1), background 160ms ease-out, border-color 160ms ease-out, color 160ms ease-out;
 }
 
-.btn-primary {
-  background: var(--rust-orange);
-  color: var(--bg-deep);
+.btn:hover { transform: translateY(-2px); }
+.btn-primary { background: var(--rust-orange); color: var(--bg-deep); border-color: var(--rust-orange); }
+.btn-primary:hover { background: var(--rust-bright); }
+.btn-outline { border-color: var(--rust-orange); color: var(--rust-bright); background: rgba(0, 173, 216, 0.06); }
+.btn-outline:hover { background: rgba(0, 173, 216, 0.12); color: var(--text-main); }
+.btn-ghost { color: var(--text-muted); border-color: var(--border-subtle); background: transparent; }
+.btn-ghost:hover { border-color: var(--border-medium); color: var(--text-main); }
+
+.proof-rail {
+  font-family: 'Fira Code', ui-monospace, SFMono-Regular, Menlo, Monaco, Consolas, monospace;
+  background: linear-gradient(180deg, rgba(19, 42, 42, 0.96), rgba(15, 46, 46, 0.92));
+  border: 1px solid rgba(93, 201, 226, 0.32);
+  border-radius: 14px;
+  padding: 1.35rem;
+  box-shadow: inset 0 1px 0 rgba(224, 245, 248, 0.04);
 }
 
-.btn-primary:hover {
-  background: var(--rust-bright);
-  transform: translateY(-2px);
-}
-
-.btn-outline {
-  border: 1px solid var(--rust-orange);
-  color: var(--rust-orange);
-  background: transparent;
-}
-
-.btn-outline:hover {
-  background: rgba(0, 173, 216, 0.1);
-}
-
-/* Specs & Stats Grid */
-.specs {
-  background: #132a2a;
-  border-radius: 8px;
-  padding: 3rem;
-  margin-bottom: 4rem;
-  border: 1px solid #1c4040;
-  animation: fade-up 0.8s ease-out 0.2s both;
-}
-
-.specs h2 {
-  font-size: 1.5rem;
-  margin-bottom: 2rem;
+.proof-kicker {
   color: var(--rust-bright);
+  text-transform: uppercase;
+  letter-spacing: 0.12em;
+  font-size: 0.76rem;
+  font-weight: 700;
+  margin-bottom: 1rem;
+}
+
+.proof-rail ul { display: grid; gap: 0.85rem; margin-bottom: 1.1rem; }
+.proof-rail li {
+  display: grid;
+  gap: 0.16rem;
+  padding-bottom: 0.85rem;
+  border-bottom: 1px dashed var(--border-subtle);
+}
+.proof-rail li:last-child { border-bottom: 0; padding-bottom: 0; }
+.proof-rail span { color: var(--text-dim); font-size: 0.76rem; text-transform: uppercase; letter-spacing: 0.08em; }
+.proof-rail strong { color: var(--text-main); font-size: 1rem; }
+.proof-link { color: var(--rust-bright); font-size: 0.86rem; font-weight: 700; text-decoration: none; }
+.proof-link:hover { color: var(--text-main); text-decoration: underline; text-underline-offset: 0.25rem; }
+
+/* Specs */
+.specs {
+  background: rgba(19, 42, 42, 0.94);
+  border-radius: 14px;
+  padding: clamp(1.5rem, 4vw, 3rem);
+  margin-bottom: 3.5rem;
+  border: 1px solid rgba(93, 201, 226, 0.24);
+  animation: fade-up 650ms cubic-bezier(0.16, 1, 0.3, 1) 80ms both;
 }
 
 .grid-3 {
   display: grid;
-  grid-template-columns: repeat(auto-fit, minmax(200px, 1fr));
-  gap: 2rem;
+  grid-template-columns: repeat(3, minmax(0, 1fr));
+  gap: 1rem;
 }
 
 .spec-item {
-  display: flex;
-  flex-direction: column;
+  display: grid;
+  gap: 0.25rem;
+  padding: 1.15rem;
+  background: rgba(12, 31, 31, 0.42);
+  border: 1px solid rgba(0, 173, 216, 0.08);
+  border-radius: 10px;
 }
 
 .spec-val {
-  font-size: 2.25rem;
+  font-family: 'Fira Code', ui-monospace, SFMono-Regular, Menlo, Monaco, Consolas, monospace;
+  font-size: clamp(1.8rem, 4vw, 2.45rem);
   font-weight: 700;
-  color: #fff;
-  margin-bottom: 0.5rem;
+  color: var(--text-main);
+  line-height: 1;
 }
 
 .spec-label {
+  font-family: 'Fira Code', ui-monospace, SFMono-Regular, Menlo, Monaco, Consolas, monospace;
   color: var(--text-muted);
-  font-size: 0.9rem;
+  font-size: 0.86rem;
+  text-transform: uppercase;
+  letter-spacing: 0.08em;
 }
 
 .arch-list {
-  margin-top: 3rem;
-  padding-top: 2rem;
-  border-top: 1px dashed #1c4040;
-  display: flex;
-  flex-wrap: wrap;
-  gap: 2rem;
-  color: var(--text-muted);
-  font-size: 0.95rem;
+  counter-reset: arch;
+  margin-top: 1.5rem;
+  padding-top: 1.5rem;
+  border-top: 1px dashed var(--border-subtle);
+  display: grid;
+  grid-template-columns: repeat(4, minmax(0, 1fr));
+  gap: 0.85rem;
 }
 
-.arch-list div::before {
-  content: '✓';
-  color: var(--rust-orange);
-  margin-right: 0.5rem;
+.arch-list li {
+  counter-increment: arch;
+  min-width: 0;
+  display: grid;
+  gap: 0.25rem;
+  padding-left: 2.1rem;
+  position: relative;
 }
 
-/* Footer */
-footer {
-  text-align: center;
-  padding: 2rem;
-  border-top: 1px solid rgba(0, 173, 216, 0.08);
-  color: var(--text-muted);
-  font-size: 0.9rem;
-  margin-top: 2rem;
-}
-
-footer a {
+.arch-list li::before {
+  content: counter(arch);
+  position: absolute;
+  left: 0;
+  top: 0.15rem;
+  width: 1.35rem;
+  height: 1.35rem;
+  display: grid;
+  place-items: center;
+  border: 1px solid var(--border-medium);
   color: var(--rust-bright);
-  text-decoration: none;
-  transition: color 0.2s;
+  font-size: 0.72rem;
+  border-radius: 4px;
 }
 
-footer a:hover {
-  color: #e0f5f8;
-}
+.arch-list strong { color: var(--text-main); font-size: 0.9rem; }
+.arch-list span { color: var(--text-muted); font-size: 0.82rem; line-height: 1.5; }
 
-/* Mobile Responsive */
-@media (max-width: 768px) {
-  main {
-    padding: 4rem 1.5rem 2rem;
-  }
-
-  .dashboard {
-    padding: 2rem 1.5rem;
-  }
-
-  nav {
-    padding: 1rem 1.5rem;
-  }
-
-  .nav-links {
-    gap: 1rem;
-  }
-
-  .hero h1 {
-    font-size: 2.5rem;
-  }
-
-  .tagline {
-    font-size: 1rem;
-  }
-
-  .ctas {
-    flex-direction: column;
-    gap: 1rem;
-  }
-}
-
-@media (max-width: 480px) {
-  .hero h1 {
-    font-size: 2rem;
-  }
-
-  .grid-3 {
-    grid-template-columns: 1fr;
-  }
-}
-
-/* Stress Tests Section */
+/* Stress Tests */
 .stress-tests {
-  background: linear-gradient(135deg, rgba(0, 173, 216, 0.05) 0%, rgba(93, 201, 226, 0.03) 100%);
-  border: 1px solid rgba(0, 173, 216, 0.15);
-  border-radius: 20px;
-  padding: 3rem;
-  margin-top: 3rem;
+  background: rgba(15, 46, 46, 0.9);
+  border: 1px solid rgba(93, 201, 226, 0.28);
+  border-radius: 18px;
+  padding: clamp(1.5rem, 4vw, 3rem);
   position: relative;
   overflow: hidden;
-  animation: fade-up 0.8s ease-out 0.3s both;
+  animation: fade-up 650ms cubic-bezier(0.16, 1, 0.3, 1) 120ms both;
 }
 
 .stress-tests::before {
   content: '';
   position: absolute;
-  top: 0;
-  left: 0;
-  right: 0;
-  height: 2px;
-  background: linear-gradient(90deg, transparent, var(--rust-bright), transparent);
-}
-
-.stress-tests h3 {
-  font-family: 'Fira Code', monospace;
-  font-size: 1.8rem;
-  color: var(--rust-bright);
-  margin-bottom: 1rem;
-  text-transform: uppercase;
-  letter-spacing: 2px;
-  text-align: center;
+  inset: 0 0 auto;
+  height: 1px;
+  background: var(--rust-orange);
+  opacity: 0.7;
 }
 
 .stress-intro {
-  text-align: center;
-  color: var(--text-muted);
-  max-width: 600px;
-  margin: 0 auto 2rem;
-  font-size: 1rem;
+  color: var(--text-soft);
+  max-width: 68ch;
+  margin: 0 auto;
   line-height: 1.7;
 }
 
 .stress-metrics {
   display: grid;
-  grid-template-columns: repeat(3, 1fr);
-  gap: 2rem;
-  margin-bottom: 2rem;
+  grid-template-columns: repeat(3, minmax(0, 1fr));
+  gap: 1rem;
+  margin-bottom: 1.5rem;
 }
 
 .stress-metric {
-  text-align: center;
-  padding: 1.5rem;
-  background: rgba(255, 255, 255, 0.03);
+  padding: 1.25rem;
+  background: rgba(12, 31, 31, 0.42);
   border-radius: 12px;
   border: 1px solid rgba(0, 173, 216, 0.1);
-  transition: all 0.3s;
-}
-
-.stress-metric:hover {
-  border-color: rgba(0, 173, 216, 0.25);
-  transform: translateY(-4px);
-  box-shadow: 0 10px 30px rgba(0, 0, 0, 0.3);
 }
 
 .metric-value {
+  font-family: 'Fira Code', ui-monospace, SFMono-Regular, Menlo, Monaco, Consolas, monospace;
   display: block;
-  font-family: 'JetBrains Mono', monospace;
-  font-size: 2.2rem;
+  font-size: clamp(1.75rem, 4vw, 2.35rem);
   font-weight: 700;
-  color: #5DC9E2;
-  margin-bottom: 0.5rem;
+  color: var(--rust-bright);
+  line-height: 1;
+  margin-bottom: 0.55rem;
 }
 
 .metric-label {
+  font-family: 'Fira Code', ui-monospace, SFMono-Regular, Menlo, Monaco, Consolas, monospace;
   display: block;
-  font-size: 0.8rem;
-  color: var(--text-muted);
+  font-size: 0.78rem;
+  color: var(--text-main);
   text-transform: uppercase;
-  letter-spacing: 0.1em;
+  letter-spacing: 0.09em;
+  margin-bottom: 0.35rem;
+}
+
+.stress-metric small {
+  color: var(--text-dim);
+  font-size: 0.76rem;
 }
 
 .stress-links {
   display: flex;
   justify-content: center;
-  gap: 1.5rem;
+  gap: 0.75rem;
   flex-wrap: wrap;
+  margin-bottom: 2rem;
 }
 
 .stress-link {
+  font-family: 'Fira Code', ui-monospace, SFMono-Regular, Menlo, Monaco, Consolas, monospace;
   display: inline-flex;
   align-items: center;
-  gap: 0.5rem;
-  padding: 0.8rem 1.5rem;
-  background: rgba(0, 173, 216, 0.08);
-  border: 1px solid rgba(0, 173, 216, 0.2);
-  border-radius: 8px;
+  padding: 0.72rem 1rem;
+  background: rgba(0, 173, 216, 0.07);
+  border: 1px solid var(--border-subtle);
+  border-radius: 6px;
   color: var(--rust-bright);
-  font-family: 'JetBrains Mono', monospace;
-  font-size: 0.9rem;
+  font-size: 0.86rem;
+  font-weight: 700;
   text-decoration: none;
-  transition: all 0.3s;
+  transition: transform 160ms cubic-bezier(0.16, 1, 0.3, 1), border-color 160ms ease-out, background 160ms ease-out;
 }
 
 .stress-link:hover {
-  background: rgba(0, 173, 216, 0.15);
-  border-color: var(--rust-orange);
-  color: #fff;
+  background: rgba(0, 173, 216, 0.12);
+  border-color: var(--border-medium);
+  color: var(--text-main);
   transform: translateY(-2px);
 }
 
-/* Reports Section */
+/* Reports */
 .reports-section {
-  margin-top: 2.5rem;
+  margin-top: 2.25rem;
   padding-top: 2rem;
-  border-top: 1px solid rgba(0, 173, 216, 0.1);
+  border-top: 1px solid var(--border-subtle);
 }
 
-.reports-section h4 {
-  font-family: 'Fira Code', monospace;
-  font-size: 1.3rem;
-  color: var(--rust-bright);
+.reports-featured {
+  display: grid;
+  grid-template-columns: repeat(3, minmax(0, 1fr));
+  gap: 1rem;
   margin-bottom: 1rem;
-  text-transform: uppercase;
-  letter-spacing: 1px;
-  text-align: center;
 }
+
+.report-feature {
+  font-family: 'Fira Code', ui-monospace, SFMono-Regular, Menlo, Monaco, Consolas, monospace;
+  min-height: 9.5rem;
+  display: grid;
+  align-content: end;
+  gap: 0.35rem;
+  padding: 1.15rem;
+  background: var(--surface);
+  border: 1px solid rgba(93, 201, 226, 0.22);
+  border-radius: 12px;
+  text-decoration: none;
+  transition: transform 160ms cubic-bezier(0.16, 1, 0.3, 1), border-color 160ms ease-out;
+}
+
+.report-feature:hover {
+  border-color: var(--border-medium);
+  transform: translateY(-2px);
+}
+
+.report-title {
+  color: var(--rust-bright);
+  font-size: 0.76rem;
+  font-weight: 700;
+  letter-spacing: 0.08em;
+  text-transform: uppercase;
+}
+.report-feature strong { color: var(--text-main); font-size: 1.15rem; }
+.report-feature small { color: var(--text-muted); }
 
 .reports-grid {
   display: grid;
-  grid-template-columns: repeat(4, 1fr);
-  gap: 0.75rem;
+  grid-template-columns: repeat(6, minmax(0, 1fr));
+  gap: 0.6rem;
   margin-bottom: 1rem;
 }
 
 .report-link {
-  display: flex;
-  flex-direction: column;
+  font-family: 'Fira Code', ui-monospace, SFMono-Regular, Menlo, Monaco, Consolas, monospace;
+  display: grid;
+  gap: 0.1rem;
   align-items: center;
-  padding: 0.75rem 0.5rem;
-  background: rgba(255, 255, 255, 0.02);
-  border: 1px solid rgba(0, 173, 216, 0.08);
+  padding: 0.7rem 0.65rem;
+  background: rgba(255, 255, 255, 0.025);
+  border: 1px solid rgba(93, 201, 226, 0.18);
   border-radius: 6px;
   text-decoration: none;
-  transition: all 0.2s;
+  transition: transform 160ms cubic-bezier(0.16, 1, 0.3, 1), background 160ms ease-out, border-color 160ms ease-out;
 }
 
 .report-link:hover {
   background: rgba(0, 173, 216, 0.08);
-  border-color: rgba(0, 173, 216, 0.2);
+  border-color: var(--border-medium);
   transform: translateY(-2px);
 }
 
 .report-date {
-  font-family: 'JetBrains Mono', monospace;
-  font-size: 0.8rem;
-  color: #5DC9E2;
-  font-weight: 500;
+  font-size: 0.74rem;
+  color: var(--rust-bright);
+  font-weight: 700;
 }
 
 .report-time {
@@ -601,6 +531,7 @@ footer a:hover {
   color: var(--text-muted);
 }
 
+.empty-reports,
 .reports-note {
   text-align: center;
   font-size: 0.85rem;
@@ -611,43 +542,59 @@ footer a:hover {
 .reports-note a {
   color: var(--rust-bright);
   text-decoration: none;
+  font-weight: 700;
+}
+.reports-note a:hover { text-decoration: underline; text-underline-offset: 0.25rem; }
+
+/* Footer */
+footer {
+  text-align: center;
+  padding: 2rem;
+  border-top: 1px solid rgba(0, 173, 216, 0.08);
+  color: var(--text-muted);
+  font-size: 0.9rem;
+  margin-top: 1rem;
 }
 
-.reports-note a:hover {
-  text-decoration: underline;
+footer a {
+  color: var(--rust-bright);
+  text-decoration: none;
+  transition: color 0.2s;
+}
+footer a:hover { color: var(--text-main); text-decoration: underline; text-underline-offset: 0.25rem; }
+
+@media (max-width: 900px) {
+  .hero { grid-template-columns: 1fr; }
+  .hero h1 { max-width: 12ch; }
+  .arch-list { grid-template-columns: repeat(2, minmax(0, 1fr)); }
+  .reports-grid { grid-template-columns: repeat(3, minmax(0, 1fr)); }
 }
 
 @media (max-width: 768px) {
-  .stress-tests {
-    padding: 2rem 1.5rem;
-  }
+  main { padding: 3rem 1.25rem 2rem; }
+  nav { padding: 1rem 1.25rem; align-items: flex-start; flex-direction: column; }
+  .nav-links { width: 100%; justify-content: space-between; }
+  .ctas { flex-direction: column; align-items: stretch; }
+  .btn { width: 100%; }
+  .grid-3,
+  .stress-metrics,
+  .reports-featured { grid-template-columns: 1fr; }
+  .stress-links { flex-direction: column; align-items: stretch; }
+  .stress-link { justify-content: center; }
+}
 
-  .stress-metrics {
-    grid-template-columns: 1fr;
-    gap: 1rem;
-  }
+@media (max-width: 520px) {
+  .hero h1 { font-size: 2.35rem; }
+  .arch-list,
+  .reports-grid { grid-template-columns: 1fr; }
+}
 
-  .stress-metric {
-    padding: 1rem;
-  }
-
-  .metric-value {
-    font-size: 1.8rem;
-  }
-
-  .stress-links {
-    flex-direction: column;
-    align-items: center;
-  }
-
-  .stress-link {
-    width: 100%;
-    max-width: 300px;
-    justify-content: center;
-  }
-
-  .reports-grid {
-    grid-template-columns: repeat(2, 1fr);
+@media (prefers-reduced-motion: reduce) {
+  *, *::before, *::after {
+    animation-duration: 0.01ms !important;
+    animation-iteration-count: 1 !important;
+    scroll-behavior: auto !important;
+    transition-duration: 0.01ms !important;
   }
 }
 


### PR DESCRIPTION
## Summary
- implements the Impeccable-inspired landing page overhaul with the same dark Go/teal benchmark-console aesthetic
- replaces decorative particles/glass/emoji treatment with functional proof rails, semantic metrics, and report-focused evidence modules
- adds PRODUCT.md, DESIGN.md, and .impeccable design/critique artifacts for future design context
- fixes the landing page Go version badge to Go 1.25 and improves semantic lists, focus states, reduced-motion handling, and CTA hierarchy

## Verification
- cd docs && /opt/data/.local/bin/mise exec -- bun run build
- local preview visual QA at http://127.0.0.1:4327/rinha2-back-end-go/
- curl smoke checks for /, /docs/, /reports/, /docs/performance/, latest report

## Notes
- Direct push to main was blocked by branch protection: GH006 required status checks expected.
- docs lint remains blocked by the repo's existing ESLint v9 setup: no eslint.config.js is present.