### PR TITLE
Enhance Rinha2 Go documentation

### DIFF
--- a/docs/src/lib/sidebar.config.ts
+++ b/docs/src/lib/sidebar.config.ts
@@ -1,0 +1,7 @@
+export const SECTION_CATEGORIES = [
+  { label: '', ids: ['home'] },
+  { label: 'Overview', ids: ['challenge', 'architecture'] },
+  { label: 'Develop', ids: ['getting-started', 'performance', 'ci-cd-pipeline'] },
+] as const;
+
+export const SECTION_ORDER = SECTION_CATEGORIES.flatMap(({ ids }) => ids);

--- a/docs/src/pages/docs/[...slug].astro
+++ b/docs/src/pages/docs/[...slug].astro
@@ -1,7 +1,7 @@
 ---
 import BaseLayout from '@/layouts/BaseLayout.astro';
 import '../../styles/docs.css';
-import { SECTION_CATEGORIES, SECTION_ORDER } from './sidebar.config';
+import { SECTION_CATEGORIES, SECTION_ORDER } from '../../lib/sidebar.config';
 
 const SLUG_LABEL: Record<string, string> = {
   home: 'Home',
@@ -37,15 +37,11 @@ const requestedSlug = Astro.params.slug;
 const isRoot = requestedSlug === undefined;
 const requestedKey = requestedSlug ?? 'home';
 
-const sectionsToRender = isRoot
-  ? SECTION_CATEGORIES.flatMap(cat => cat.ids)
-      .map(slug => ({ slug, page: pagesBySlug[slug] }))
-      .filter(s => s.page)
-  : (() => {
-      const page = pagesBySlug[requestedKey];
-      if (!page) return [];
-      return [{ slug: requestedSlug!, page }];
-    })();
+const sectionsToRender = (() => {
+  const page = pagesBySlug[requestedKey];
+  if (!page) return [];
+  return [{ slug: requestedKey, page }];
+})();
 
 export function getStaticPaths() {
   return [
@@ -56,8 +52,13 @@ export function getStaticPaths() {
 
 const pageTitle = isRoot ? 'rinha2-back-end-go - Documentation' : `${SLUG_LABEL[requestedSlug] ?? requestedSlug} - rinha2-back-end-go`;
 const base = import.meta.env.BASE_URL;
-const docsBase = base.replace(/\/$/, '') + '/docs';
-const backHomeUrl = base.replace(/\/$/, '') + '/';
+const siteBase = base.replace(/\/$/, '');
+const docsBase = siteBase + '/docs';
+const backHomeUrl = siteBase + '/';
+const latestReportUrl = siteBase + '/reports/';
+const currentNavId = requestedKey;
+const docsHref = (id: string) => id === 'home' ? `${docsBase}/` : `${docsBase}/${id}/`;
+const docsSearchIndex = SECTION_ORDER.map(id => ({ id, label: SLUG_LABEL[id] ?? id, href: docsHref(id) }));
 ---
 
 <BaseLayout title={pageTitle}>
@@ -76,10 +77,11 @@ const backHomeUrl = base.replace(/\/$/, '') + '/';
     <div class="sidebar-header">
       <h1 class="repo-title">rinha2-back-end-go</h1>
       <p class="repo-description">
-        Go 1.25 implementation of Rinha de Backend 2024/Q1 — minimal, flat, lightning-fast
-        fictional bank API built for performance under constraints
+        Go 1.25 benchmark notes for a compact banking API under 1.5 CPU and 550MB.
       </p>
-      <input type="text" id="searchInput" class="search-box" placeholder="Search documentation..." aria-label="Search documentation" hidden={!isRoot}>
+      <label class="search-label" for="searchInput">Search</label>
+      <input type="search" id="searchInput" class="search-box" placeholder="> architecture, k6, pgx..." aria-label="Search documentation navigation" autocomplete="off">
+      <div class="search-hint" id="searchHint">Press Enter to open the first match.</div>
     </div>
     <div class="sidebar-nav-container">
       {SECTION_CATEGORIES.map((cat) => {
@@ -90,7 +92,13 @@ const backHomeUrl = base.replace(/\/$/, '') + '/';
             <ul>
               {catIds.map((id) => (
                 <li>
-                  <a class="nav-item" href={`${docsBase}/#${id}`} data-nav-id={id}>
+                  <a
+                    class:list={["nav-item", { active: currentNavId === id }]}
+                    href={docsHref(id)}
+                    data-nav-id={id}
+                    data-search-label={SLUG_LABEL[id]}
+                    aria-current={currentNavId === id ? 'page' : undefined}
+                  >
                     {SLUG_LABEL[id]}
                   </a>
                 </li>
@@ -101,8 +109,10 @@ const backHomeUrl = base.replace(/\/$/, '') + '/';
       })}
     </div>
     <div class="sidebar-footer">
-      <a href={backHomeUrl} class="back-home">← Back to home</a>
-      <a href="https://github.com/jonathanperis/rinha2-back-end-go" target="_blank" rel="noopener noreferrer">View on GitHub</a>
+      <div class="sidebar-footer-label">Project</div>
+      <a href={backHomeUrl} class="back-home">← Landing page</a>
+      <a href={latestReportUrl}>Stress reports</a>
+      <a href="https://github.com/jonathanperis/rinha2-back-end-go" target="_blank" rel="noopener noreferrer">Source on GitHub ↗</a>
       <div>Built by Jonathan Peris</div>
     </div>
   </aside>
@@ -120,121 +130,86 @@ const backHomeUrl = base.replace(/\/$/, '') + '/';
     </main>
   </div>
 
-  {requestedSlug && <script is:inline define:vars={{ slug: requestedSlug, isRoot: isRoot }}>window.__docsSlug = slug; window.__isRoot = isRoot;</script>}
+  <script is:inline define:vars={{ slug: requestedSlug, isRoot: isRoot, docsSearchIndex }}>window.__docsSlug = slug; window.__isRoot = isRoot; window.__docsSearchIndex = docsSearchIndex;</script>
 
   <script is:inline>
     document.addEventListener('DOMContentLoaded', () => {
       const menuToggle = document.getElementById('menuToggle');
       const sidebar = document.getElementById('sidebar');
       const overlay = document.getElementById('overlay');
+      const navItems = Array.from(document.querySelectorAll('.nav-item'));
+      const searchInput = document.getElementById('searchInput');
+      const searchHint = document.getElementById('searchHint');
 
-      function toggleMenu() {
-        const isOpen = sidebar.classList.toggle('open');
-        overlay.classList.toggle('open');
-        if (menuToggle) menuToggle.setAttribute('aria-expanded', String(isOpen));
+      function setMenu(open) {
+        if (!sidebar || !overlay || !menuToggle) return;
+        sidebar.classList.toggle('open', open);
+        overlay.classList.toggle('open', open);
+        menuToggle.setAttribute('aria-expanded', String(open));
       }
 
-      if (menuToggle) menuToggle.addEventListener('click', toggleMenu);
-      if (overlay) overlay.addEventListener('click', toggleMenu);
+      if (menuToggle) menuToggle.addEventListener('click', () => setMenu(!sidebar.classList.contains('open')));
+      if (overlay) overlay.addEventListener('click', () => setMenu(false));
+      navItems.forEach(item => item.addEventListener('click', () => {
+        if (window.innerWidth <= 768) setMenu(false);
+      }));
 
-      const isRoot = window.__isRoot !== false;
-      const prefersReducedMotion = !window.matchMedia('(prefers-reduced-motion: no-preference)').matches;
-      const sections = document.querySelectorAll('section.doc-section');
-      const navItems = document.querySelectorAll('.nav-item');
+      if (searchInput) {
+        searchInput.addEventListener('input', () => {
+          const query = searchInput.value.trim().toLowerCase();
+          let visibleCount = 0;
 
-      // Auto-scroll: root uses section slug; single-section lets browser handle deep-link hashes
-      if (isRoot) {
-        const targetSlug = window.__docsSlug;
-        const hash = window.location.hash;
-        const sectionId = targetSlug || (hash && hash.length > 1 ? hash.slice(1) : null);
-        if (sectionId) {
-          const target = document.getElementById(sectionId);
-          if (target) {
-            setTimeout(() => target.scrollIntoView({ behavior: prefersReducedMotion ? 'auto' : 'smooth' }), 100);
+          navItems.forEach(item => {
+            const label = (item.dataset.searchLabel || item.textContent || '').toLowerCase();
+            const visible = query === '' || label.includes(query);
+            const row = item.closest('li');
+            if (row) row.style.display = visible ? '' : 'none';
+            if (visible) visibleCount++;
+          });
+
+          document.querySelectorAll('[data-category]').forEach(group => {
+            const visibleItems = Array.from(group.querySelectorAll('li')).filter(li => li.style.display !== 'none');
+            group.style.display = visibleItems.length > 0 ? '' : 'none';
+          });
+
+          if (searchHint) {
+            searchHint.textContent = query === ''
+              ? 'Press Enter to open the first match.'
+              : `${visibleCount} matching section${visibleCount === 1 ? '' : 's'}`;
           }
-        }
-      }
+        });
 
-      // Scrollspy + nav click: only meaningful with multiple sections
-      if (isRoot && sections.length > 1) {
-        const observer = new IntersectionObserver((entries) => {
-          entries.forEach(entry => {
-            if (entry.isIntersecting) {
-              const sectionId = entry.target.id;
-              navItems.forEach(item => {
-                item.classList.toggle('active', item.dataset.navId === sectionId);
-                if (item.dataset.navId === sectionId) {
-                  item.scrollIntoView({ behavior: prefersReducedMotion ? 'auto' : 'smooth', block: 'nearest' });
-                }
-              });
-            }
-          });
-        }, { root: null, rootMargin: '-80px 0px -60% 0px', threshold: 0 });
-
-        sections.forEach(section => observer.observe(section));
-
-        navItems.forEach(item => {
-          item.addEventListener('click', () => {
-            if (window.innerWidth <= 768) toggleMenu();
-          });
+        searchInput.addEventListener('keydown', event => {
+          if (event.key !== 'Enter') return;
+          const firstVisible = navItems.find(item => item.closest('li')?.style.display !== 'none');
+          if (firstVisible) window.location.href = firstVisible.href;
         });
       }
 
-      // Search: only on root (full tree); single-section has nothing to filter
-      if (isRoot) {
-        const searchInput = document.getElementById('searchInput');
-        if (searchInput) {
-          searchInput.addEventListener('input', (e) => {
-            const query = e.target.value.toLowerCase();
-            const content = document.getElementById('mainContent');
-            if (!content) return;
+      document.querySelectorAll('pre').forEach((pre) => {
+        const code = pre.querySelector('code');
+        if (!code || pre.querySelector('.copy-code')) return;
+        const wrapper = document.createElement('div');
+        wrapper.className = 'code-frame';
+        pre.parentNode.insertBefore(wrapper, pre);
+        wrapper.appendChild(pre);
 
-            if (query === '') {
-              sections.forEach(s => s.classList.remove('hidden-section'));
-              navItems.forEach(item => {
-                item.style.display = '';
-                item.parentElement.style.display = '';
-              });
-              document.querySelectorAll('.sidebar-category-group').forEach(group => {
-                group.style.display = '';
-                const catLabel = group.querySelector('.sidebar-category');
-                if (catLabel) catLabel.style.display = '';
-              });
-              return;
-            }
-
-            sections.forEach(section => {
-              const text = section.textContent?.toLowerCase() ?? '';
-              const navItem = document.querySelector(`.nav-item[data-nav-id="${section.id}"]`);
-              const li = navItem ? navItem.parentElement : null;
-
-              if (text.includes(query)) {
-                section.classList.remove('hidden-section');
-                if (li) li.style.display = '';
-              } else {
-                section.classList.add('hidden-section');
-                if (li) li.style.display = 'none';
-              }
-            });
-
-            // Hide empty categories
-            document.querySelectorAll('.sidebar-category-group').forEach(group => {
-              const items = group.querySelectorAll('.nav-item');
-              let visibleCount = 0;
-              items.forEach(item => {
-                const id = item.dataset.navId;
-                const sec = document.getElementById(id ?? '');
-                const vis = !sec || !sec.classList.contains('hidden-section');
-                item.style.display = vis ? '' : 'none';
-                if (vis) visibleCount++;
-              });
-              const catLabel = group.querySelector('.sidebar-category');
-              if (catLabel) catLabel.style.display = visibleCount === 0 ? 'none' : '';
-              group.style.display = visibleCount === 0 ? 'none' : '';
-            });
-          });
-        }
-      }
+        const button = document.createElement('button');
+        button.type = 'button';
+        button.className = 'copy-code';
+        button.textContent = 'Copy';
+        button.addEventListener('click', async () => {
+          try {
+            await navigator.clipboard.writeText(code.textContent || '');
+            button.textContent = 'Copied';
+            setTimeout(() => { button.textContent = 'Copy'; }, 1600);
+          } catch (error) {
+            button.textContent = 'Select';
+            pre.focus();
+          }
+        });
+        wrapper.appendChild(button);
+      });
     });
   </script>
 </BaseLayout>

--- a/docs/src/pages/docs/sidebar.config.ts
+++ b/docs/src/pages/docs/sidebar.config.ts
@@ -1,7 +1,0 @@
-export const SECTION_CATEGORIES = [
-  { label: "", ids: ["home"] },
-  { label: "Overview", ids: ["challenge", "architecture"] },
-  { label: "Develop", ids: ["getting-started", "performance", "ci-cd-pipeline"] },
-] as const;
-
-export const SECTION_ORDER = SECTION_CATEGORIES.flatMap(({ ids }) => ids);

--- a/docs/src/styles/docs.css
+++ b/docs/src/styles/docs.css
@@ -1,22 +1,29 @@
 :root {
   --bg: #0c1f1f;
+  --bg-grid: rgba(93, 201, 226, 0.035);
   --sidebar-bg: #132a2a;
+  --surface: #102828;
+  --surface-strong: #163636;
   --text-primary: #e0f5f8;
   --text-muted: #7dd3e8;
   --text-body: #a8dde8;
+  --text-dim: #6cb8c8;
   --accent: #00ADD8;
   --accent-hover: #5DC9E2;
-  --code-bg: #0c1f1f;
+  --code-bg: #071d1f;
   --code-text: #e0f5f8;
-  --code-border: #0a3040;
-  --sidebar-width: 260px;
-  --border: #0a3040;
+  --code-border: rgba(93, 201, 226, 0.26);
+  --sidebar-width: 286px;
+  --border: rgba(93, 201, 226, 0.2);
+  --border-quiet: rgba(93, 201, 226, 0.11);
+  --focus-ring: 0 0 0 3px rgba(93, 201, 226, 0.28);
 }
 
 * { box-sizing: border-box; }
 
 html {
-  font-family: 'Fira Code', monospace;
+  font-family: 'Inter', ui-sans-serif, system-ui, -apple-system, BlinkMacSystemFont, 'Segoe UI', sans-serif;
+  scroll-padding-top: 24px;
 }
 
 @media (prefers-reduced-motion: no-preference) {
@@ -25,77 +32,73 @@ html {
 
 @media (prefers-reduced-motion: reduce) {
   *, *::before, *::after {
-    animation-duration: 0s !important;
+    animation-duration: 0.01ms !important;
     animation-iteration-count: 1 !important;
-    transition-duration: 0s !important;
+    transition-duration: 0.01ms !important;
+    scroll-behavior: auto !important;
   }
 }
 
-/* Custom scrollbar */
 html {
   scrollbar-color: var(--accent-hover) var(--bg);
   scrollbar-width: thin;
 }
 
-::-webkit-scrollbar {
-  width: 6px;
-  height: 6px;
-}
-
-::-webkit-scrollbar-track {
-  background: var(--bg);
-  border-left: 1px solid rgba(10, 48, 64, 0.5);
-}
-
-::-webkit-scrollbar-thumb {
-  background: var(--accent-hover);
-  border-radius: 3px;
-  transition: background 0.2s;
-}
-
-::-webkit-scrollbar-thumb:hover {
-  background: #8ad4e8;
-}
-
-::-webkit-scrollbar-corner {
-  background: var(--bg);
-}
+::-webkit-scrollbar { width: 6px; height: 6px; }
+::-webkit-scrollbar-track { background: var(--bg); }
+::-webkit-scrollbar-thumb { background: var(--accent-hover); border-radius: 3px; }
+::-webkit-scrollbar-thumb:hover { background: #8ad4e8; }
+::-webkit-scrollbar-corner { background: var(--bg); }
 
 body {
   margin: 0;
-  padding: 0;
-  background: var(--bg);
+  min-height: 100vh;
+  background:
+    linear-gradient(90deg, var(--bg-grid) 1px, transparent 1px),
+    linear-gradient(180deg, rgba(93, 201, 226, 0.025) 1px, transparent 1px),
+    radial-gradient(circle at 78% 8%, rgba(0, 173, 216, 0.07), transparent 32rem),
+    var(--bg);
+  background-size: 44px 44px, 44px 44px, auto, auto;
   color: var(--text-primary);
   display: flex;
+}
+
+body, button, input { font: inherit; }
+
+a:focus-visible,
+button:focus-visible,
+input:focus-visible {
+  outline: 2px solid var(--accent-hover);
+  outline-offset: 3px;
+  box-shadow: var(--focus-ring);
 }
 
 .sidebar {
   position: fixed;
-  top: 0;
-  left: 0;
+  inset: 0 auto 0 0;
   width: var(--sidebar-width);
   height: 100vh;
-  background: var(--sidebar-bg);
+  background: rgba(19, 42, 42, 0.98);
   display: flex;
   flex-direction: column;
   border-right: 1px solid var(--border);
   z-index: 100;
-  transition: transform 0.3s ease;
+  overflow: hidden;
+  transition: transform 0.24s cubic-bezier(0.16, 1, 0.3, 1);
 }
 
-.sidebar-header {
-  padding: 24px 24px 16px;
-}
+.sidebar-header { padding: 24px 24px 18px; }
 
 .repo-title {
+  font-family: 'Fira Code', ui-monospace, SFMono-Regular, Menlo, Monaco, Consolas, monospace;
   font-size: 18px;
   font-weight: 700;
-  margin: 0 0 4px;
+  margin: 0 0 8px;
   color: var(--text-primary);
-  letter-spacing: -0.01em;
+  letter-spacing: -0.03em;
   display: flex;
   align-items: center;
-  gap: 8px;
+  gap: 9px;
 }
 
 .repo-title::before {
@@ -105,86 +108,96 @@ body {
   height: 10px;
   background: var(--accent);
   border-radius: 3px;
+  box-shadow: 0 0 0 4px rgba(0, 173, 216, 0.08);
   flex-shrink: 0;
 }
 
 .repo-description {
   font-size: 13px;
-  color: var(--text-muted);
-  margin: 0 0 16px;
-  line-height: 1.5;
+  color: var(--text-body);
+  margin: 0 0 18px;
+  line-height: 1.55;
 }
+
+.search-label,
+.sidebar-category,
+.sidebar-footer-label {
+  font-family: 'Fira Code', ui-monospace, SFMono-Regular, Menlo, Monaco, Consolas, monospace;
+  font-size: 11px;
+  font-weight: 700;
+  text-transform: uppercase;
+  letter-spacing: 0.1em;
+  color: var(--accent-hover);
+}
+
+.search-label { display: block; margin: 0 0 6px; }
 
 .search-box {
   width: 100%;
-  background: #000;
+  background: var(--code-bg);
   border: 1px solid var(--border);
   color: var(--text-primary);
   border-radius: 6px;
-  padding: 8px 12px;
-  font-size: 14px;
+  padding: 9px 11px;
+  font-size: 13px;
   outline: none;
-  transition: border-color 0.2s;
-  font-family: 'Fira Code', monospace;
+  transition: border-color 0.16s ease-out, background 0.16s ease-out;
+  font-family: 'Fira Code', ui-monospace, SFMono-Regular, Menlo, Monaco, Consolas, monospace;
 }
-.search-box:focus { border-color: var(--accent); }
-.search-box::placeholder { color: var(--text-muted); }
+.search-box:focus { border-color: var(--accent); background: #092326; }
+.search-box::placeholder { color: var(--text-dim); }
+.search-hint { margin-top: 7px; color: var(--text-dim); font-size: 11px; line-height: 1.4; }
 
 .sidebar-nav-container {
-  flex: 1;
+  flex: 1 1 auto;
+  min-height: 0;
   overflow-y: auto;
-  padding: 8px 16px 24px;
+  padding: 6px 16px 24px;
 }
-.sidebar-nav-container ul {
-  list-style: none;
-  padding: 0;
-  margin: 0;
-}
-.sidebar-nav-container li { margin-bottom: 2px; }
-
-.sidebar-category {
-  font-size: 11px;
-  font-weight: 600;
-  text-transform: uppercase;
-  letter-spacing: 0.08em;
-  color: var(--text-muted);
-  padding: 12px 12px 4px;
-  margin-top: 8px;
-}
+.sidebar-nav-container ul { list-style: none; padding: 0; margin: 0; }
+.sidebar-nav-container li { margin-bottom: 3px; }
+.sidebar-category { padding: 15px 12px 6px; margin-top: 8px; }
 
 .nav-item {
   display: block;
-  padding: 8px 12px;
+  padding: 9px 12px;
   color: var(--text-muted);
   text-decoration: none;
   font-size: 14px;
   border-radius: 6px;
-  transition: all 0.2s;
+  border: 1px solid transparent;
+  transition: color 0.16s ease-out, background 0.16s ease-out, border-color 0.16s ease-out;
 }
 .nav-item:hover {
   color: var(--text-primary);
-  background: rgba(255, 255, 255, 0.05);
+  background: rgba(93, 201, 226, 0.06);
+  text-decoration: none;
 }
-.nav-item.active {
-  color: var(--accent);
-  background: rgba(0, 173, 216, 0.1);
-  font-weight: 500;
+.nav-item.active,
+.nav-item[aria-current='page'] {
+  color: var(--text-primary);
+  background: rgba(0, 173, 216, 0.12);
+  border-color: rgba(93, 201, 226, 0.22);
+  font-weight: 700;
 }
 
 .sidebar-footer {
-  padding: 16px 24px;
+  flex: 0 0 auto;
+  padding: 14px 24px 16px;
   border-top: 1px solid var(--border);
   font-size: 12px;
-  color: var(--text-muted);
+  color: var(--text-dim);
+  background: rgba(12, 31, 31, 0.28);
 }
+.sidebar-footer-label { margin-bottom: 10px; }
 .sidebar-footer a {
   color: var(--text-muted);
   text-decoration: none;
   display: block;
-  margin-bottom: 8px;
-  transition: color 0.2s;
+  margin-bottom: 9px;
+  transition: color 0.16s ease-out;
 }
-.sidebar-footer a:hover { color: var(--text-primary); }
+.sidebar-footer a:hover { color: var(--text-primary); text-decoration: underline; text-underline-offset: 0.22rem; }
 
 .content-wrapper {
   margin-left: var(--sidebar-width);
@@ -196,176 +209,254 @@ body {
 
 .content {
   width: 100%;
-  max-width: 1100px;
-  padding: 48px 48px;
+  max-width: 1080px;
+  padding: clamp(2rem, 5vw, 4.5rem) clamp(1.25rem, 5vw, 4rem) 4rem;
+}
+
+.doc-section {
+  scroll-margin-top: 80px;
+  background: rgba(19, 42, 42, 0.68);
+  border: 1px solid var(--border-quiet);
+  border-radius: 18px;
+  padding: clamp(1.4rem, 4vw, 3rem);
+  box-shadow: inset 0 1px 0 rgba(224, 245, 248, 0.035);
+}
+.doc-section.hidden-section { display: none; }
+
+h1, h2, h3, h4 {
+  color: var(--text-primary);
+  line-height: 1.18;
+  letter-spacing: -0.035em;
 }
 
 h1 {
-  font-size: 32px;
+  font-family: 'Fira Code', ui-monospace, SFMono-Regular, Menlo, Monaco, Consolas, monospace;
+  font-size: clamp(2rem, 4.8vw, 3.35rem);
   font-weight: 700;
-  letter-spacing: -0.02em;
-  margin: 0 0 8px;
-  color: var(--text-primary);
+  margin: 0 0 1rem;
+  max-width: 14ch;
 }
 
 h2 {
-  font-size: 22px;
-  font-weight: 600;
-  letter-spacing: -0.01em;
-  margin: 48px 0 16px;
-  padding-bottom: 8px;
+  font-size: clamp(1.45rem, 3vw, 2rem);
+  font-weight: 750;
+  margin: 2.6rem 0 0.9rem;
+  padding-bottom: 0.65rem;
   border-bottom: 1px solid var(--border);
-  color: var(--text-primary);
   scroll-margin-top: 80px;
 }
 
 h3 {
-  font-size: 18px;
-  font-weight: 600;
-  margin: 32px 0 12px;
-  color: var(--text-primary);
+  font-size: 1.12rem;
+  font-weight: 750;
+  margin: 1.8rem 0 0.75rem;
   scroll-margin-top: 80px;
 }
 
 p {
-  font-size: 15px;
+  font-size: 15.5px;
   line-height: 1.75;
   color: var(--text-body);
-  margin: 0 0 16px;
+  margin: 0 0 1rem;
+  max-width: 74ch;
 }
 
-a {
-  color: var(--accent);
-  text-decoration: none;
-}
-a:hover { text-decoration: underline; }
+a { color: var(--accent-hover); text-decoration: none; font-weight: 650; }
+a:hover { text-decoration: underline; text-underline-offset: 0.22rem; }
 
-pre:not(.astro-code) {
+.docs-status-grid,
+.docs-card-grid,
+.docs-metric-grid {
+  display: grid;
+  gap: 1rem;
+  margin: 1.5rem 0 2rem;
+}
+.docs-status-grid { grid-template-columns: repeat(4, minmax(0, 1fr)); }
+.docs-card-grid { grid-template-columns: repeat(2, minmax(0, 1fr)); }
+.docs-metric-grid { grid-template-columns: repeat(3, minmax(0, 1fr)); }
+
+.status-tile,
+.doc-card,
+.metric-tile {
+  background: rgba(12, 31, 31, 0.58);
+  border: 1px solid var(--border);
+  border-radius: 12px;
+  padding: 1rem;
+}
+.status-tile span,
+.metric-tile span,
+.doc-card span {
+  display: block;
+  color: var(--text-dim);
+  font-family: 'Fira Code', ui-monospace, SFMono-Regular, Menlo, Monaco, Consolas, monospace;
+  font-size: 0.72rem;
+  font-weight: 700;
+  letter-spacing: 0.09em;
+  text-transform: uppercase;
+  margin-bottom: 0.35rem;
+}
+.status-tile strong,
+.metric-tile strong {
+  display: block;
+  color: var(--accent-hover);
+  font-family: 'Fira Code', ui-monospace, SFMono-Regular, Menlo, Monaco, Consolas, monospace;
+  font-size: clamp(1.1rem, 2.5vw, 1.5rem);
+  line-height: 1.1;
+}
+.doc-card a {
+  display: inline-flex;
+  color: var(--text-primary);
+  font-size: 1.03rem;
+  margin-bottom: 0.4rem;
+}
+.doc-card p,
+.metric-tile p { margin: 0; font-size: 14px; line-height: 1.6; }
+
+.arch-diagram {
+  overflow-x: auto;
   background: var(--code-bg);
   border: 1px solid var(--code-border);
-  border-radius: 8px;
-  padding: 16px 20px;
-  overflow-x: auto;
-  margin: 24px 0;
-}
-pre:not(.astro-code) > code {
-  background: transparent;
-  padding: 0;
-  border-radius: 0;
-  color: var(--code-text);
+  border-radius: 12px;
+  padding: 1rem 1.2rem;
+  color: var(--text-primary);
+  font-family: 'Fira Code', ui-monospace, SFMono-Regular, Menlo, Monaco, Consolas, monospace;
   font-size: 13px;
+  line-height: 1.55;
 }
+
+.code-frame { position: relative; margin: 1.5rem 0; }
+pre:not(.astro-code),
 pre.astro-code {
+  background: var(--code-bg) !important;
   border: 1px solid var(--code-border);
-  border-radius: 8px;
-  padding: 16px 20px;
-  margin: 24px 0;
+  border-radius: 10px;
+  padding: 1.15rem 1.25rem;
+  overflow-x: auto;
+  margin: 0;
 }
+pre:not(.astro-code) > code,
 pre.astro-code > code {
   background: transparent;
   padding: 0;
   border-radius: 0;
   color: inherit;
+  font-size: 13px;
+  font-family: 'Fira Code', ui-monospace, SFMono-Regular, Menlo, Monaco, Consolas, monospace;
 }
+.copy-code {
+  position: absolute;
+  top: 0.55rem;
+  right: 0.55rem;
+  border: 1px solid var(--border);
+  border-radius: 5px;
+  background: rgba(19, 42, 42, 0.94);
+  color: var(--accent-hover);
+  font-family: 'Fira Code', ui-monospace, SFMono-Regular, Menlo, Monaco, Consolas, monospace;
+  font-size: 12px;
+  font-weight: 700;
+  padding: 0.35rem 0.55rem;
+  cursor: pointer;
+}
+.copy-code:hover { color: var(--text-primary); border-color: var(--accent-hover); }
+
 :not(pre) > code {
   background: var(--code-bg);
   color: var(--code-text);
+  border: 1px solid rgba(93, 201, 226, 0.14);
   border-radius: 4px;
   padding: 2px 6px;
   font-size: 13px;
-  font-family: 'Fira Code', monospace;
+  font-family: 'Fira Code', ui-monospace, SFMono-Regular, Menlo, Monaco, Consolas, monospace;
 }
 
 table {
   width: 100%;
-  border-collapse: collapse;
-  border-radius: 8px;
+  border-collapse: separate;
+  border-spacing: 0;
+  border-radius: 10px;
   overflow: hidden;
-  margin: 24px 0;
+  margin: 1.5rem 0;
   font-size: 14px;
   border: 1px solid var(--border);
 }
-th, td { padding: 10px 16px; text-align: left; }
+th, td { padding: 11px 14px; text-align: left; vertical-align: top; }
 th {
-  background: var(--sidebar-bg);
+  background: rgba(22, 54, 54, 0.95);
   color: var(--text-primary);
-  font-weight: 600;
+  font-weight: 750;
   border-bottom: 1px solid var(--border);
 }
-td {
-  border-bottom: 1px solid var(--border);
-  color: var(--text-body);
-}
-tr:nth-child(even) { background: rgba(255, 255, 255, 0.02); }
+td { border-bottom: 1px solid var(--border-quiet); color: var(--text-body); }
+tr:nth-child(even) { background: rgba(93, 201, 226, 0.025); }
+tr:hover td { background: rgba(0, 173, 216, 0.045); }
 tr:last-child td { border-bottom: none; }
+td:first-child, td:nth-child(2):has(code), td code { font-family: 'Fira Code', ui-monospace, SFMono-Regular, Menlo, Monaco, Consolas, monospace; }
 
 blockquote {
-  margin: 24px 0;
-  padding: 12px 20px;
-  background: var(--sidebar-bg);
-  border-left: 3px solid var(--accent);
-  border-radius: 0 6px 6px 0;
+  margin: 1.5rem 0;
+  padding: 1rem 1.2rem;
+  background: rgba(0, 173, 216, 0.07);
+  border: 1px solid var(--border);
+  border-radius: 10px;
   color: var(--text-muted);
 }
 blockquote p { margin: 0; }
 
-hr {
-  border: none;
-  border-top: 1px solid var(--border);
-  margin: 40px 0;
-}
-
-ul, ol { padding-left: 24px; margin: 16px 0; }
-li { margin-bottom: 8px; color: var(--text-body); font-size: 15px; line-height: 1.6; }
-
-section.doc-section { scroll-margin-top: 80px; }
-section.doc-section + section.doc-section { margin-top: 80px; }
-section.doc-section.hidden-section { display: none; }
+hr { border: none; border-top: 1px solid var(--border); margin: 2rem 0; }
+ul, ol { padding-left: 1.35rem; margin: 1rem 0; }
+li { margin-bottom: 0.5rem; color: var(--text-body); font-size: 15px; line-height: 1.65; max-width: 78ch; }
 
 .mobile-header {
   display: none;
   position: sticky;
   top: 0;
-  background: var(--bg);
+  background: rgba(12, 31, 31, 0.98);
   border-bottom: 1px solid var(--border);
-  padding: 16px 24px;
+  padding: 0.9rem 1rem;
   z-index: 90;
   align-items: center;
-  gap: 16px;
+  gap: 1rem;
 }
 
 .menu-toggle {
-  background: none;
-  border: none;
+  background: rgba(0, 173, 216, 0.08);
+  border: 1px solid var(--border);
+  border-radius: 6px;
   color: var(--text-primary);
   cursor: pointer;
-  padding: 0;
-  display: flex;
-  flex-direction: column;
+  padding: 0.7rem;
+  display: grid;
   gap: 4px;
 }
-.menu-toggle span {
-  display: block;
-  width: 20px;
-  height: 2px;
-  background: currentcolor;
-  border-radius: 2px;
-}
+.menu-toggle span { display: block; width: 20px; height: 2px; background: currentcolor; border-radius: 2px; }
 
 .overlay {
   display: none;
   position: fixed;
   inset: 0;
-  background: rgba(0, 0, 0, 0.5);
-  backdrop-filter: blur(2px);
+  background: rgba(7, 29, 31, 0.7);
   z-index: 95;
 }
 
+@media (max-width: 980px) {
+  .docs-status-grid, .docs-metric-grid { grid-template-columns: repeat(2, minmax(0, 1fr)); }
+  .docs-card-grid { grid-template-columns: 1fr; }
+}
+
 @media (max-width: 768px) {
-  .sidebar { transform: translateX(-100%); }
+  body { display: block; }
+  .sidebar { transform: translateX(-100%); width: min(88vw, 320px); }
   .sidebar.open { transform: translateX(0); }
   .content-wrapper { margin-left: 0; width: 100%; }
-  .content { padding: 32px 24px; }
+  .content { padding: 1rem; }
+  .doc-section { border-radius: 14px; padding: 1.25rem; }
   .mobile-header { display: flex; }
   .overlay.open { display: block; }
+  h1 { font-size: 2rem; max-width: none; }
+  table { display: block; overflow-x: auto; white-space: nowrap; }
+}
+
+@media (max-width: 520px) {
+  .docs-status-grid, .docs-metric-grid { grid-template-columns: 1fr; }
+  .copy-code { position: static; margin-top: 0.5rem; }
 }

--- a/docs/wiki/architecture.md
+++ b/docs/wiki/architecture.md
@@ -1,35 +1,58 @@
 # Architecture
 
-## Overview
+## Runtime topology
 
-The system follows a shared architecture across all Rinha de Backend implementations: two API instances behind an Nginx reverse proxy, with a single PostgreSQL database and an observability stack.
+The runtime shape is deliberately small: two Go API instances sit behind NGINX, and both API containers share a single PostgreSQL database. Observability and k6 are present for local development and stress testing, but they are outside the challenge resource budget.
 
-## Services
+<div class="arch-diagram">
+<pre>[k6 runner] ──▶ [nginx :9999 · least_conn]
+                       ├──▶ [webapi1-go :8080]
+                       └──▶ [webapi2-go :8080]
+                                  │
+                                  ▼
+                         [postgresql :5432]
+                                  │
+                                  └──▶ stored procedures</pre>
+</div>
+
+## Challenge-counted services
 
 | Service | Role | CPU | RAM |
 |---------|------|-----|-----|
-| webapi1 | Go 1.25 API instance (chi/v5 + pgx/v5) | 0.4 | 100MB |
-| webapi2 | Go 1.25 API instance (chi/v5 + pgx/v5) | 0.4 | 100MB |
-| nginx | Reverse proxy / load balancer (least-conn) | 0.2 | 20MB |
-| postgresql | Database with stored procedures | 0.5 | 330MB |
-| k6 | Load testing | (not counted) | (not counted) |
-| grafana + influxdb | Observability dashboards | (not counted) | (not counted) |
+| `webapi1-go` | Go 1.25 API instance using chi/v5 and pgx/v5 | 0.4 | 100MB |
+| `webapi2-go` | Second identical API instance | 0.4 | 100MB |
+| `nginx` | Reverse proxy and load balancer using `least_conn` | 0.2 | 20MB |
+| `db` | PostgreSQL 16 with stored procedures | 0.5 | 330MB |
 
-## Load Balancing
+Total counted envelope: **1.5 CPU** and **550MB RAM**.
 
-Nginx uses `least_conn` strategy to distribute requests across the two API instances.
+## Development and test services
 
-## Database
+| Service | Purpose | Counted in challenge budget? |
+|---------|---------|------------------------------|
+| `k6` | Runs the external stress-test suite | No |
+| `postgres-exporter` | Exposes PostgreSQL metrics | No |
+| `prometheus` | Stores local metrics | No |
+| `grafana` | Local dashboards | No |
+| `influxdb` | Optional k6 time-series output in development mode | No |
 
-Business logic is implemented in PostgreSQL stored procedures. The database is tuned for maximum write performance:
+## Load balancing
 
-- `synchronous_commit=0` — no wait for WAL flush
-- `fsync=0` — skip fsync on writes
-- `full_page_writes=0` — skip full page writes
+NGINX uses `least_conn` to distribute requests across the two API instances. That keeps pressure away from a busy worker when concurrent transaction bursts hit the same endpoint family.
 
-## Implementation Details
+## Database strategy
 
-- Minimal single-file Go API (~221 lines)
-- chi/v5 lightweight HTTP router
-- pgx/v5 PostgreSQL driver with built-in connection pooling
-- Multi-stage Docker build for minimal container image size
+Business rules run in PostgreSQL stored procedures so balance updates and validation stay close to the data. The database is tuned for write-heavy benchmark behavior:
+
+- `synchronous_commit=0`: do not wait for WAL flush on each commit.
+- `fsync=0`: skip forced syncs during the benchmark run.
+- `full_page_writes=0`: reduce write amplification.
+
+These settings are benchmark-oriented. They are useful for understanding the contest trade-off, not a general production banking recommendation.
+
+## Implementation notes
+
+- The API implementation is intentionally compact, roughly 221 lines for the Go API source.
+- `chi/v5` provides the HTTP router.
+- `pgx/v5` and `pgxpool` handle PostgreSQL access and pooling.
+- The Dockerfile uses a multi-stage build for a smaller runtime image.

--- a/docs/wiki/challenge.md
+++ b/docs/wiki/challenge.md
@@ -2,25 +2,37 @@
 
 ## Rinha de Backend 2024/Q1
 
-The Rinha de Backend is a Brazilian backend programming challenge. The 2024/Q1 edition simulates a fictional bank called "Rinha Financeira" that manages up to 5 named clients, each seeded at startup with a credit limit and initial balance.
+Rinha de Backend is a Brazilian backend programming challenge. The 2024/Q1 edition models a tiny financial API: five predefined clients start with credit limits and balances, and the service must accept concurrent credits, debits, and statement reads under a strict container resource cap.
 
-## Endpoints
+## Required API contract
 
-Two API endpoints are required:
+| Endpoint | Method | Expected behavior |
+|----------|--------|-------------------|
+| `/clientes/{id}/transacoes` | `POST` | Submit a debit (`d`) or credit (`c`) transaction for clients 1 through 5. |
+| `/clientes/{id}/extrato` | `GET` | Return current balance, credit limit, statement timestamp, and recent transactions. |
 
-| Endpoint | Method | Description |
-|----------|--------|-------------|
-| `/clientes/{id}/transacoes` | POST | Submit a debit or credit transaction for a client (IDs 1-5) |
-| `/clientes/{id}/extrato` | GET | Get a client's current balance, credit limit, and recent transactions |
+## Validation rules
 
-## Constraints
+- Client IDs outside the seeded range should fail.
+- Transaction values must be positive integers.
+- Transaction type is constrained to debit (`d`) or credit (`c`).
+- Descriptions are short strings and must satisfy the official challenge limits.
+- Debits cannot exceed the current balance plus the configured client limit.
 
-The challenge imposes strict resource limits across all containers combined:
+## Resource constraints
 
-- **1.5 CPU total** shared across all services
-- **550MB RAM total** shared across all services
-- The system is stress tested using Grafana k6 with concurrent users submitting transactions and querying statements
+The official stack budget is intentionally tight:
 
-## Source
+<div class="docs-metric-grid">
+  <div class="metric-tile"><span>Total CPU</span><strong>1.5</strong><p>Shared across API, NGINX, and PostgreSQL.</p></div>
+  <div class="metric-tile"><span>Total RAM</span><strong>550MB</strong><p>Shared across all challenge-counted containers.</p></div>
+  <div class="metric-tile"><span>Workload</span><strong>k6</strong><p>Concurrent transactions, validations, and statement queries.</p></div>
+</div>
+
+## Why this implementation is interesting
+
+The repository explores a compact Go approach: a small API surface, a simple NGINX fan-out, and PostgreSQL stored procedures for the hot transaction path. The goal is not to build a feature-complete banking system; it is to study performance trade-offs under a fixed resource envelope.
+
+## Source specification
 
 Full specification: [github.com/zanfranceschi/rinha-de-backend-2024-q1](https://github.com/zanfranceschi/rinha-de-backend-2024-q1)

--- a/docs/wiki/ci-cd-pipeline.md
+++ b/docs/wiki/ci-cd-pipeline.md
@@ -2,28 +2,34 @@
 
 ## Workflows
 
-This repository uses four GitHub Actions workflows:
+The repository uses GitHub Actions for pull-request checks, main-branch releases, security scanning, and the GitHub Pages documentation deploy.
 
-### build-check.yml
+| Workflow | Trigger | Purpose |
+|----------|---------|---------|
+| `build-check.yml` | Pull requests | Build the Go application and run a Docker Compose health check before merge. |
+| `main-release.yml` | Push to `main` | Build and push multi-platform GHCR images, run container health checks, and execute k6 validation. |
+| `codeql.yml` | Push, pull request, weekly schedule | Run CodeQL security analysis for Go code. |
+| `deploy.yml` | Push to `main` | Build the Astro documentation site and deploy GitHub Pages. |
 
-- **Trigger:** Pull requests
-- **Steps:** Builds the Go application and runs a Docker Compose health check to verify the service starts correctly
-- **Purpose:** Catch build failures and regressions before merging
+## Release path
 
-### main-release.yml
+```text
+pull request
+  └─ build-check.yml
+       └─ merge to main
+            ├─ main-release.yml  -> GHCR image + k6 evidence
+            ├─ codeql.yml        -> security analysis
+            └─ deploy.yml        -> GitHub Pages documentation
+```
 
-- **Trigger:** Push to main branch
-- **Steps:** Builds the Go application, creates a multi-platform Docker image (amd64/arm64), pushes to GitHub Container Registry (GHCR), runs container health check, and executes k6 load tests
-- **Purpose:** Automated release of production-ready container images with stress test validation
+## Published artifacts
 
-### codeql.yml
+- Documentation: [jonathanperis.github.io/rinha2-back-end-go/docs/](https://jonathanperis.github.io/rinha2-back-end-go/docs/)
+- Stress reports: [jonathanperis.github.io/rinha2-back-end-go/reports/](https://jonathanperis.github.io/rinha2-back-end-go/reports/)
+- Container image: `ghcr.io/jonathanperis/rinha2-back-end-go:latest`
 
-- **Trigger:** Push to main, pull requests, and weekly schedule
-- **Steps:** Runs CodeQL security analysis on Go code
-- **Purpose:** Detect security vulnerabilities and code quality issues
+## Operator notes
 
-### deploy.yml
-
-- **Trigger:** Push to main branch
-- **Steps:** Deploys the `docs/` directory to GitHub Pages using the GitHub Actions deployment model
-- **Purpose:** Publish project documentation and landing page
+- PR checks protect the documentation and runtime from obvious regressions.
+- Main-branch workflows are the deployment path; the live docs update after the GitHub Pages workflow finishes.
+- Stress-test reports should be treated as run-specific evidence, not timeless proof of a single absolute ranking.

--- a/docs/wiki/getting-started.md
+++ b/docs/wiki/getting-started.md
@@ -2,9 +2,12 @@
 
 ## Prerequisites
 
-- Docker with Docker Compose
+- Docker with Docker Compose.
+- A shell with `curl` for quick smoke tests.
 
-## Clone and Run
+> The full benchmark stack depends on a reachable Docker daemon. In this Hermes environment the Docker CLI exists, but daemon access is not available, so local compose verification must run on a machine with Docker permissions.
+
+## Clone and run
 
 ```bash
 git clone https://github.com/jonathanperis/rinha2-back-end-go.git
@@ -12,29 +15,44 @@ cd rinha2-back-end-go
 docker compose up nginx -d --build
 ```
 
-## Access
+The API is exposed through NGINX at `http://localhost:9999`.
 
-The API is available at `http://localhost:9999`
+## Smoke-test the API
 
-## Endpoints
-
-| Endpoint | Method | Description |
-|----------|--------|-------------|
-| `/clientes/{id}/transacoes` | POST | Submit debit or credit transaction |
-| `/clientes/{id}/extrato` | GET | Get account balance statement |
-
-## Example Requests
-
-### Create Transaction
+Create a credit transaction:
 
 ```bash
-curl -X POST http://localhost:9999/clientes/1/transacoes \
+curl -sS -X POST http://localhost:9999/clientes/1/transacoes \
   -H "Content-Type: application/json" \
   -d '{"valor": 1000, "tipo": "c", "descricao": "deposito"}'
 ```
 
-### Get Statement
+Read the statement:
 
 ```bash
-curl http://localhost:9999/clientes/1/extrato
+curl -sS http://localhost:9999/clientes/1/extrato
 ```
+
+Try an invalid debit to confirm validation still rejects overdrafts beyond the credit limit:
+
+```bash
+curl -i -X POST http://localhost:9999/clientes/1/transacoes \
+  -H "Content-Type: application/json" \
+  -d '{"valor": 999999999, "tipo": "d", "descricao": "limite"}'
+```
+
+## Useful compose targets
+
+| Command | Use |
+|---------|-----|
+| `docker compose up nginx -d --build` | Build and start the challenge-counted stack behind NGINX. |
+| `docker compose logs -f nginx webapi1-go webapi2-go db` | Follow request path and database startup logs. |
+| `docker compose up k6` | Run the configured k6 service after the API is healthy. |
+| `docker compose down -v` | Stop services and remove the database volume for a clean run. |
+
+## Endpoint summary
+
+| Endpoint | Method | Payload / response |
+|----------|--------|--------------------|
+| `/clientes/{id}/transacoes` | `POST` | JSON body with `valor`, `tipo`, and `descricao`. Returns updated `limite` and `saldo`. |
+| `/clientes/{id}/extrato` | `GET` | Returns `saldo` metadata and recent `ultimas_transacoes`. |

--- a/docs/wiki/home.md
+++ b/docs/wiki/home.md
@@ -2,28 +2,64 @@
 title: Home
 ---
 
-# Home
+# Documentation
 
-Go 1.25 implementation for the Rinha de Backend 2024/Q1 challenge. Manages a fictional bank API with transaction processing and balance statements under strict resource constraints (1.5 CPU, 550MB RAM total across all containers). Written in ~221 lines of pure Go.
+Operator notes for the Go 1.25 Rinha de Backend 2024/Q1 implementation. The docs are split into short pages so each route has one job: understand the challenge, inspect the runtime shape, run the stack, read the performance evidence, or follow the CI pipeline.
 
-## Wiki Pages
+<div class="docs-status-grid">
+  <div class="status-tile"><span>Runtime</span><strong>Go 1.25</strong></div>
+  <div class="status-tile"><span>Resource cap</span><strong>1.5 CPU</strong></div>
+  <div class="status-tile"><span>Memory cap</span><strong>550MB</strong></div>
+  <div class="status-tile"><span>API shape</span><strong>2 routes</strong></div>
+</div>
 
-| Page | Description |
-|------|-------------|
-| [Challenge](challenge) | What is Rinha de Backend 2024/Q1 |
-| [Architecture](architecture) | Stack, services, resource constraints |
-| [Getting Started](getting-started) | Prerequisites and how to run |
-| [Performance](performance) | Results, benchmarks, resource usage |
-| [CI/CD Pipeline](ci-cd-pipeline) | GitHub Actions workflows |
+## Start here
 
-## Key Features
+<div class="docs-card-grid">
+  <div class="doc-card">
+    <span>01 · challenge</span>
+    <a href="challenge/">Read the contest contract</a>
+    <p>Required endpoints, client model, resource limits, and the source specification.</p>
+  </div>
+  <div class="doc-card">
+    <span>02 · architecture</span>
+    <a href="architecture/">Inspect the runtime topology</a>
+    <p>NGINX least-connection balancing, two Go API containers, PostgreSQL stored procedures, and observability services.</p>
+  </div>
+  <div class="doc-card">
+    <span>03 · getting started</span>
+    <a href="getting-started/">Run the local stack</a>
+    <p>Clone, compose, smoke-test transactions, and query statements through port 9999.</p>
+  </div>
+  <div class="doc-card">
+    <span>04 · performance</span>
+    <a href="performance/">Review benchmark evidence</a>
+    <p>Resource envelope, published report links, and the meaning of the headline claims.</p>
+  </div>
+</div>
 
-- Go 1.25 with minimal standard library usage (~221 lines)
-- chi/v5 router for high-performance HTTP routing
-- pgx/v5 with pgxpool for efficient PostgreSQL connection pooling
-- PostgreSQL stored procedures for server-side business logic
-- Extreme throughput under strict resource constraints
+## Implementation snapshot
 
----
+| Signal | Value | Source |
+|--------|-------|--------|
+| Language | Go 1.25 | `README.md`, site metadata |
+| Router | chi/v5 | `go.mod`, API implementation |
+| Database client | pgx/v5 with pgxpool | `go.mod`, API implementation |
+| Database strategy | PostgreSQL stored procedures | `docker-entrypoint-initdb.d/` |
+| Load balancer | NGINX `least_conn` | `nginx.conf` |
+| Reports | Static k6 HTML archive | `docs/public/reports/` |
 
-*[GitHub](https://github.com/jonathanperis/rinha2-back-end-go) · [Jonathan Peris](https://jonathanperis.github.io/)*
+## Fast path
+
+```bash
+git clone https://github.com/jonathanperis/rinha2-back-end-go.git
+cd rinha2-back-end-go
+docker compose up nginx -d --build
+curl http://localhost:9999/clientes/1/extrato
+```
+
+## Proof links
+
+- [Latest stress reports](../reports/)
+- [Source repository](https://github.com/jonathanperis/rinha2-back-end-go)
+- [Rinha de Backend 2024/Q1 specification](https://github.com/zanfranceschi/rinha-de-backend-2024-q1)

--- a/docs/wiki/performance.md
+++ b/docs/wiki/performance.md
@@ -1,22 +1,39 @@
 # Performance
 
-## Resource Constraints
+## Resource envelope
 
-The challenge allows a total of 1.5 CPU and 550MB RAM across all containers.
+The project targets the official Rinha de Backend 2024/Q1 limit of **1.5 CPU** and **550MB RAM** across the challenge-counted stack.
 
-## Actual Usage
+| Metric | Limit | Documented result | Margin |
+|--------|-------|-------------------|--------|
+| RAM | 550MB | ~250MB | About 60% below the limit |
+| Response time | Challenge-sensitive | < 800ms | All documented requests under the headline threshold |
+| API replicas | 2 | 2 | Balanced by NGINX `least_conn` |
 
-| Metric | Limit | Actual | Margin |
-|--------|-------|--------|--------|
-| RAM | 550MB | ~250MB | 60% below limit |
-| Response time | - | < 800ms | All requests |
+## Published reports
 
-## Results
+Stress-test HTML reports are published with the static site under [`/reports/`](../reports/). Use them as the durable evidence trail for individual runs rather than treating a single number as universal performance truth.
 
-- All requests completed under 800ms
-- Total RAM usage of approximately 250MB, which is 60% below the 550MB limit
-- Built for learning purposes
+## How to read the results
 
-## Stress Testing
+- **Resource usage** is the important first-pass signal because the challenge budget is very small.
+- **Latency claims** should be read alongside the exact k6 run and host environment that produced the report.
+- **Repeated runs matter.** Backend benchmark results can vary across hosts and CI runners, so compare multiple reports before drawing conclusions.
+- **Correctness still wins.** A fast run is only useful if transaction validation, limits, and final statements remain correct.
 
-Load tests are run using the shared [rinha2-back-end-k6](https://github.com/jonathanperis/rinha2-back-end-k6) test suite, which simulates concurrent users performing debits, credits, validations, and statement queries.
+## Benchmark-oriented choices
+
+<div class="docs-metric-grid">
+  <div class="metric-tile"><span>Hot path</span><strong>SQL</strong><p>Stored procedures keep balance mutation close to PostgreSQL.</p></div>
+  <div class="metric-tile"><span>Fan-out</span><strong>2 APIs</strong><p>Two Go API containers share requests behind NGINX.</p></div>
+  <div class="metric-tile"><span>DB tuning</span><strong>write-heavy</strong><p>PostgreSQL settings reduce write overhead for contest runs.</p></div>
+</div>
+
+## Run locally
+
+```bash
+docker compose up nginx -d --build
+docker compose up k6
+```
+
+For development dashboards, start the observability services too and keep the k6 service in development mode. For publishable evidence, prefer the generated HTML reports that are archived by the site.


### PR DESCRIPTION
## Summary\n- convert docs from an all-in-one root page into focused per-section routes\n- add benchmark-console cards, architecture diagram, richer run/performance/CI notes\n- improve sidebar navigation/search, active states, code copy buttons, and docs styling\n\n## Verification\n- bun install\n- bun run build\n- local browser QA of /docs/ and /docs/architecture/\n\nNote: bun run lint currently fails because the docs package has ESLint 9 but no eslint.config.* file.