### PR TITLE
docs: refresh readme and wiki against code

### DIFF
--- a/README.md
+++ b/README.md
@@ -1,74 +1,126 @@
 # rinha2-back-end-go
 
-> Go 1.25 implementation for the Rinha de Backend 2024/Q1 challenge with chi router, pgx driver, and PostgreSQL stored procedures
+> Go 1.25.0 implementation for the Rinha de Backend 2024/Q1 challenge with chi/v5, pgx/v5, PostgreSQL stored procedures, and an NGINX `least_conn` fan-out.
 
 [![Build Check](https://github.com/jonathanperis/rinha2-back-end-go/actions/workflows/build-check.yml/badge.svg)](https://github.com/jonathanperis/rinha2-back-end-go/actions/workflows/build-check.yml) [![Main Release](https://github.com/jonathanperis/rinha2-back-end-go/actions/workflows/main-release.yml/badge.svg)](https://github.com/jonathanperis/rinha2-back-end-go/actions/workflows/main-release.yml) [![CodeQL](https://github.com/jonathanperis/rinha2-back-end-go/actions/workflows/codeql.yml/badge.svg)](https://github.com/jonathanperis/rinha2-back-end-go/actions/workflows/codeql.yml) [![License: MIT](https://img.shields.io/badge/License-MIT-yellow.svg)](LICENSE)
 
-**[Live demo →](https://jonathanperis.github.io/rinha2-back-end-go/)** | **[Documentation →](https://jonathanperis.github.io/rinha2-back-end-go/docs/)**
+**[Live demo →](https://jonathanperis.github.io/rinha2-back-end-go/)** | **[Documentation →](https://jonathanperis.github.io/rinha2-back-end-go/docs/)** | **[Stress reports →](https://jonathanperis.github.io/rinha2-back-end-go/reports/)**
 
 ---
 
 ## About
 
-A Go implementation of the Brazilian backend challenge Rinha de Backend 2024/Q1, where a fictional bank API must handle concurrent transactions under strict resource constraints (1.5 CPU, 550MB RAM total). Built as a minimal single-file API (~221 lines) using chi/v5 for routing and pgx/v5 for PostgreSQL access, with business logic in stored procedures. Built for learning purposes.
+A Go implementation of the Brazilian backend challenge Rinha de Backend 2024/Q1, where a fictional bank API must handle concurrent transactions under strict resource constraints: **1.5 CPU** and **550MB RAM** across the two API containers, NGINX, and PostgreSQL. The current API is intentionally compact: `src/WebApi/main.go` contains the whole HTTP layer, input validation, and database calls, while balance mutation and statement assembly live in PostgreSQL functions.
 
-## Tech Stack
+This project is a benchmark/learning implementation, not a production banking service. The database settings intentionally trade durability for benchmark throughput.
 
-| Technology | Version | Purpose |
-|-----------|---------|---------|
-| Go | 1.25 | API implementation |
-| chi | v5 | HTTP router |
-| pgx | v5 | PostgreSQL driver with connection pool |
-| PostgreSQL | - | Database with stored procedures |
-| Nginx | - | Reverse proxy and load balancer (least-conn) |
-| Docker | - | Multi-stage build and orchestration |
-| k6 | - | Stress testing |
+## Source-backed implementation facts
 
-## Features
+| Area | Current value | Source |
+|---|---|---|
+| Go toolchain | `go 1.25.0` | `src/WebApi/go.mod` |
+| Router | `github.com/go-chi/chi/v5 v5.2.5` | `src/WebApi/go.mod`, `main.go` |
+| Database client | `github.com/jackc/pgx/v5 v5.9.2` with `pgxpool` | `src/WebApi/go.mod`, `main.go` |
+| API process port | `:8080` | `src/WebApi/main.go`, `src/WebApi/Dockerfile` |
+| Public stack port | `:9999` through NGINX | `nginx.conf`, `docker-compose.yml` |
+| API replicas | `webapi1-go`, `webapi2-go` | `docker-compose.yml`, `prod/docker-compose.yml` |
+| Database | PostgreSQL with `Clientes` and `Transacoes` UNLOGGED tables | `docker-entrypoint-initdb.d/rinha.dump.sql` |
+| Stored procedures | `InsertTransacao`, `GetSaldoClienteById` | `docker-entrypoint-initdb.d/rinha.dump.sql` |
+| Reports archive | 34 committed k6 HTML reports | `docs/public/reports/` |
 
-- Minimal single-file API implementation (~221 lines of Go)
-- Idiomatic Go with chi/v5 router and pgx/v5 driver
-- PostgreSQL stored procedures for server-side business logic
-- PostgreSQL tuned with synchronous_commit=0, fsync=0, full_page_writes=0
-- All requests under 800ms at 250MB RAM usage (60% below limit)
+## Runtime topology
 
-## Getting Started
+```text
+client / k6
+  └─▶ nginx :9999 (`least_conn`)
+        ├─▶ webapi1-go :8080
+        └─▶ webapi2-go :8080
+              └─▶ PostgreSQL :5432
+                    ├─ InsertTransacao(id, valor, tipo, descricao)
+                    └─ GetSaldoClienteById(id)
+```
 
-### Prerequisites
+Challenge-counted resource limits in the compose files are:
 
-- Docker with Docker Compose
+| Service | CPU | Memory |
+|---|---:|---:|
+| `webapi1-go` | 0.4 | 100MB |
+| `webapi2-go` | 0.4 | 100MB |
+| `nginx` | 0.2 | 20MB |
+| `db` | 0.5 | 330MB |
+| **Total** | **1.5** | **550MB** |
 
-### Quick Start
+Development-only observability services (`postgres-exporter`, Prometheus, Grafana, InfluxDB) and the `k6` runner are included in the root compose file but are outside the challenge budget.
+
+## API contract
+
+| Method | Path | Success | Validation / errors |
+|---|---|---|---|
+| `GET` | `/healthz` | `200`, body `Healthy` | Health check only. |
+| `GET` | `/clientes/{id}/extrato` | `200`, JSON statement with `saldo` and `ultimas_transacoes` | Non-integer IDs return `400`; IDs outside 1–5 return `404`. |
+| `POST` | `/clientes/{id}/transacoes` | `200`, JSON with `id`, `limite`, and updated `saldo` | Invalid JSON returns `400`; IDs outside 1–5 return `404`; invalid transaction fields return `422`. |
+
+Transaction validation in `main.go` currently requires:
+
+- `tipo` exactly `c` or `d`.
+- `descricao` non-empty and at most 10 characters.
+- `valor` greater than zero.
+- Debits are accepted by the stored procedure only when the resulting balance is not below `-Limite`; credits are always allowed.
+
+## Getting started
 
 ```bash
 git clone https://github.com/jonathanperis/rinha2-back-end-go.git
 cd rinha2-back-end-go
 docker compose up nginx -d --build
+curl -sS http://localhost:9999/healthz
+curl -sS http://localhost:9999/clientes/1/extrato
 ```
 
-API available at `http://localhost:9999`
+Run the local k6 service after the API is healthy:
 
-| Endpoint | Method | Description |
-|----------|--------|-------------|
-| `/clientes/{id}/transacoes` | POST | Submit debit or credit transaction |
-| `/clientes/{id}/extrato` | GET | Get account balance statement |
-
-## Project Structure
-
+```bash
+docker compose up k6 --build --force-recreate
 ```
+
+> This workspace has Docker CLI installed but no reachable Docker daemon, so full compose verification must run in CI or on a host with Docker daemon access.
+
+## Project structure
+
+```text
 rinha2-back-end-go/
-├── src/WebApi/         — API implementation
-├── docker-compose.yml  — Full stack: API x2, Nginx, PostgreSQL, k6, observability
-└── .github/workflows/  — CI/CD pipelines
+├── src/WebApi/
+│   ├── main.go          # HTTP handlers, validation, pgxpool calls
+│   ├── go.mod / go.sum  # Go 1.25.0, chi/v5, pgx/v5
+│   └── Dockerfile       # golang:1.25-alpine3.21 builder → alpine:3.23 runtime
+├── docker-entrypoint-initdb.d/
+│   └── rinha.dump.sql   # Dev schema, seed clients, stored procedures
+├── docker-compose.yml   # Dev stack: API x2, NGINX, PostgreSQL, k6, observability
+├── prod/
+│   ├── docker-compose.yml
+│   └── conf/            # Prod compose inputs used by CI release/load-test jobs
+├── nginx.conf           # Dev NGINX config using least_conn
+├── docs/                # Astro Pages site, wiki markdown, report archive
+└── .github/workflows/   # Build, release, CodeQL, Pages deploy
 ```
 
 ## CI/CD
 
-- **PR:** Go build + Docker health check (`build-check.yml`)
-- **Main:** Build + Multi-platform Docker push (amd64/arm64) to GHCR + k6 load test + GitHub Pages report (`main-release.yml`)
-- **Security:** CodeQL analysis on push, PRs, and weekly schedule (`codeql.yml`)
-- **Docs:** Auto-generated from wiki and deployed to GitHub Pages (`deploy-docs.yml`)
-- **Image:** `ghcr.io/jonathanperis/rinha2-back-end-go:latest`
+| Workflow | Trigger | What it does |
+|---|---|---|
+| `build-check.yml` | Pull requests and manual dispatch | Filters runtime-relevant changes, builds the Go app, and runs a Docker Compose health check for `/healthz`. |
+| `main-release.yml` | Push to `main` and manual dispatch | Builds amd64/arm64 GHCR images, creates the `latest` manifest, runs the prod compose health check, and uploads a k6 report artifact. |
+| `codeql.yml` | Push, pull request, weekly schedule | Runs Go CodeQL with manual build mode when Go/source workflow paths change. |
+| `deploy.yml` | Push to `main` and manual dispatch | Calls the shared Pages docs workflow with Bun to build/deploy the Astro site. |
+
+Published image tags:
+
+- `ghcr.io/jonathanperis/rinha2-back-end-go:latest` — multi-arch manifest.
+- `ghcr.io/jonathanperis/rinha2-back-end-go:latest-arm64` — arm64 image tag used before manifest merge.
+
+## Documentation
+
+The public docs are generated from `docs/wiki/*.md` via `docs/src/pages/docs/[...slug].astro`. The route set is defined in `docs/src/lib/sidebar.config.ts`, and the stress report index reads committed HTML reports from `docs/public/reports/`.
 
 ## License
 

--- a/docs/README.md
+++ b/docs/README.md
@@ -1,6 +1,17 @@
 # Docs
 
-Astro static site deployed to GitHub Pages.
+Astro static site for `rinha2-back-end-go`, deployed to GitHub Pages by `.github/workflows/deploy.yml` using the shared `jonathanperis/.github/.github/workflows/pages-docs-deploy.yml` workflow.
+
+## Source layout
+
+| Path | Purpose |
+|---|---|
+| `wiki/*.md` | Source Markdown for `/docs/` pages. |
+| `src/pages/docs/[...slug].astro` | Route-based docs renderer and sidebar/search wiring. |
+| `src/lib/sidebar.config.ts` | Ordered docs route list. Add new wiki pages here. |
+| `src/pages/reports/index.astro` | Builds the stress-report archive from `public/reports/*.html`. |
+| `public/reports/` | Committed k6 HTML reports copied into the final site. |
+| `out/` | Generated Astro build output; do not edit by hand. |
 
 ## Commands
 
@@ -8,10 +19,13 @@ Run from this directory (`docs/`):
 
 | Command | Action |
 |---|---|
-| `bun install` | Install dependencies |
-| `bun run dev` | Start dev server |
-| `bun run build` | Build to `./out/` |
-| `bun run preview` | Preview production build locally |
+| `bun install` | Install dependencies. |
+| `bun run dev` | Start the local Astro dev server. |
+| `bun run lint` | Run ESLint. |
+| `bun run build` | Build the site to `./out/`. |
+| `bun run preview` | Preview the production build locally. |
+
+For production-equivalent route bases, build with `NODE_ENV=production`; `astro.config.mjs` sets `base: '/rinha2-back-end-go'` only in production.
 
 ## Environment
 
@@ -19,4 +33,4 @@ Copy `.env.example` to `.env` and fill in local values when needed.
 
 | Variable | Description |
 |---|---|
-| `PUBLIC_GA_ID` | Optional Google Analytics 4 Measurement ID |
+| `PUBLIC_GA_ID` | Optional Google Analytics 4 Measurement ID consumed by `src/components/Analytics.astro`. |

--- a/docs/wiki/architecture.md
+++ b/docs/wiki/architecture.md
@@ -2,27 +2,28 @@
 
 ## Runtime topology
 
-The runtime shape is deliberately small: two Go API instances sit behind NGINX, and both API containers share a single PostgreSQL database. Observability and k6 are present for local development and stress testing, but they are outside the challenge resource budget.
+The challenge path is deliberately small: two Go API instances sit behind NGINX, and both API containers share one PostgreSQL database. The root compose file also includes observability and k6 services for development, but those services are outside the official resource budget.
 
 <div class="arch-diagram">
-<pre>[k6 runner] ──▶ [nginx :9999 · least_conn]
+<pre>[client / k6] ──▶ [nginx :9999 · least_conn]
                        ├──▶ [webapi1-go :8080]
                        └──▶ [webapi2-go :8080]
                                   │
                                   ▼
                          [postgresql :5432]
                                   │
-                                  └──▶ stored procedures</pre>
+                                  ├──▶ InsertTransacao(...)
+                                  └──▶ GetSaldoClienteById(...)</pre>
 </div>
 
 ## Challenge-counted services
 
-| Service | Role | CPU | RAM |
-|---------|------|-----|-----|
-| `webapi1-go` | Go 1.25 API instance using chi/v5 and pgx/v5 | 0.4 | 100MB |
-| `webapi2-go` | Second identical API instance | 0.4 | 100MB |
-| `nginx` | Reverse proxy and load balancer using `least_conn` | 0.2 | 20MB |
-| `db` | PostgreSQL 16 with stored procedures | 0.5 | 330MB |
+| Service | Role | CPU | RAM | Source |
+|---------|------|-----|-----|--------|
+| `webapi1-go` | Go 1.25.0 API instance using chi/v5 and pgx/v5 | 0.4 | 100MB | `docker-compose.yml`, `prod/docker-compose.yml` |
+| `webapi2-go` | Second identical API instance | 0.4 | 100MB | `docker-compose.yml`, `prod/docker-compose.yml` |
+| `nginx` | Reverse proxy and load balancer using `least_conn` | 0.2 | 20MB | `nginx.conf`, compose files |
+| `db` | PostgreSQL with stored procedures | 0.5 | 330MB | compose files, SQL dump |
 
 Total counted envelope: **1.5 CPU** and **550MB RAM**.
 
@@ -30,29 +31,37 @@ Total counted envelope: **1.5 CPU** and **550MB RAM**.
 
 | Service | Purpose | Counted in challenge budget? |
 |---------|---------|------------------------------|
-| `k6` | Runs the external stress-test suite | No |
+| `k6` | Runs the external stress-test suite (`MODE=dev` in root compose, `MODE=prod` in `prod/`) | No |
 | `postgres-exporter` | Exposes PostgreSQL metrics | No |
 | `prometheus` | Stores local metrics | No |
 | `grafana` | Local dashboards | No |
 | `influxdb` | Optional k6 time-series output in development mode | No |
 
-## Load balancing
+## HTTP layer
 
-NGINX uses `least_conn` to distribute requests across the two API instances. That keeps pressure away from a busy worker when concurrent transaction bursts hit the same endpoint family.
+`src/WebApi/main.go` creates a chi router and exposes three routes:
+
+| Method | Route | Handler |
+|---|---|---|
+| `GET` | `/healthz` | `healthzHandler` returns `Healthy`. |
+| `GET` | `/clientes/{id}/extrato` | `getExtratoHandler` validates the ID and calls `GetSaldoClienteById($1)`. |
+| `POST` | `/clientes/{id}/transacoes` | `postTransacaoHandler` validates JSON and calls `InsertTransacao($1, $2, $3, $4)`. |
+
+The HTTP server listens on `:8080`, uses a 5-second read timeout and a 10-second write timeout, and each database operation runs with a 5-second request-scoped context timeout.
 
 ## Database strategy
 
-Business rules run in PostgreSQL stored procedures so balance updates and validation stay close to the data. The database is tuned for write-heavy benchmark behavior:
+Business rules run in PostgreSQL stored procedures so balance updates and validation stay close to the data. The schema uses UNLOGGED `Clientes` and `Transacoes` tables and an index on `(ClienteId, Id DESC)` for recent statement retrieval.
+
+Benchmark-oriented PostgreSQL flags configured in both compose files:
 
 - `synchronous_commit=0`: do not wait for WAL flush on each commit.
 - `fsync=0`: skip forced syncs during the benchmark run.
 - `full_page_writes=0`: reduce write amplification.
+- `checkpoint_timeout=600` and `max_wal_size=4096`: reduce checkpoint pressure during runs.
 
-These settings are benchmark-oriented. They are useful for understanding the contest trade-off, not a general production banking recommendation.
+These settings are useful for understanding the contest trade-off; they are not general production-banking defaults.
 
-## Implementation notes
+## Build images
 
-- The API implementation is intentionally compact, roughly 221 lines for the Go API source.
-- `chi/v5` provides the HTTP router.
-- `pgx/v5` and `pgxpool` handle PostgreSQL access and pooling.
-- The Dockerfile uses a multi-stage build for a smaller runtime image.
+`src/WebApi/Dockerfile` currently builds with `golang:1.25-alpine3.21` and copies the binary into an `alpine:3.23` runtime image. CI publishes GHCR images from that Dockerfile.

--- a/docs/wiki/challenge.md
+++ b/docs/wiki/challenge.md
@@ -2,22 +2,41 @@
 
 ## Rinha de Backend 2024/Q1
 
-Rinha de Backend is a Brazilian backend programming challenge. The 2024/Q1 edition models a tiny financial API: five predefined clients start with credit limits and balances, and the service must accept concurrent credits, debits, and statement reads under a strict container resource cap.
+Rinha de Backend is a Brazilian backend programming challenge. The 2024/Q1 edition models a tiny financial API: five predefined clients start with credit limits and zero balances, and the service must accept concurrent credits, debits, and statement reads under a strict container resource cap.
 
 ## Required API contract
 
-| Endpoint | Method | Expected behavior |
-|----------|--------|-------------------|
-| `/clientes/{id}/transacoes` | `POST` | Submit a debit (`d`) or credit (`c`) transaction for clients 1 through 5. |
-| `/clientes/{id}/extrato` | `GET` | Return current balance, credit limit, statement timestamp, and recent transactions. |
+| Endpoint | Method | Expected behavior | Current implementation note |
+|----------|--------|-------------------|-----------------------------|
+| `/clientes/{id}/transacoes` | `POST` | Submit a debit (`d`) or credit (`c`) transaction for clients 1 through 5. | Implemented in `postTransacaoHandler`; returns `id`, `limite`, and updated `saldo`. |
+| `/clientes/{id}/extrato` | `GET` | Return current balance, credit limit, statement timestamp, and recent transactions. | Implemented in `getExtratoHandler`; returns `saldo` and up to 10 `ultimas_transacoes`. |
+
+The repository also exposes `GET /healthz` for compose/CI health checks; it is not part of the original banking contract.
+
+## Seeded clients
+
+| Client | Limit |
+|---:|---:|
+| 1 | 100000 |
+| 2 | 80000 |
+| 3 | 1000000 |
+| 4 | 10000000 |
+| 5 | 500000 |
+
+The same IDs and limits appear in both the Go `clientes` map and the SQL seed data.
 
 ## Validation rules
 
-- Client IDs outside the seeded range should fail.
-- Transaction values must be positive integers.
-- Transaction type is constrained to debit (`d`) or credit (`c`).
-- Descriptions are short strings and must satisfy the official challenge limits.
-- Debits cannot exceed the current balance plus the configured client limit.
+Current validation is split between Go and PostgreSQL:
+
+- Non-integer client IDs return `400` from the Go handlers.
+- Client IDs outside 1–5 return `404` before the database call.
+- Invalid JSON transaction bodies return `400`.
+- `tipo` must be exactly debit (`d`) or credit (`c`).
+- `descricao` must be non-empty and at most 10 characters.
+- `valor` must be greater than zero.
+- Debits cannot push the balance below `-Limite`; credits are allowed unconditionally.
+- Invalid transaction fields return `422`.
 
 ## Resource constraints
 
@@ -31,7 +50,7 @@ The official stack budget is intentionally tight:
 
 ## Why this implementation is interesting
 
-The repository explores a compact Go approach: a small API surface, a simple NGINX fan-out, and PostgreSQL stored procedures for the hot transaction path. The goal is not to build a feature-complete banking system; it is to study performance trade-offs under a fixed resource envelope.
+The repository explores a compact Go approach: a small HTTP layer, a simple NGINX fan-out, and PostgreSQL stored procedures for the hot transaction path. The goal is not to build a feature-complete banking system; it is to study performance trade-offs under a fixed resource envelope.
 
 ## Source specification
 

--- a/docs/wiki/ci-cd-pipeline.md
+++ b/docs/wiki/ci-cd-pipeline.md
@@ -2,24 +2,25 @@
 
 ## Workflows
 
-The repository uses GitHub Actions for pull-request checks, main-branch releases, security scanning, and the GitHub Pages documentation deploy.
+The repository uses GitHub Actions for pull-request checks, main-branch releases, security scanning, and GitHub Pages documentation deployment.
 
 | Workflow | Trigger | Purpose |
 |----------|---------|---------|
-| `build-check.yml` | Pull requests | Build the Go application and run a Docker Compose health check before merge. |
-| `main-release.yml` | Push to `main` | Build and push multi-platform GHCR images, run container health checks, and execute k6 validation. |
-| `codeql.yml` | Push, pull request, weekly schedule | Run CodeQL security analysis for Go code. |
-| `deploy.yml` | Push to `main` | Build the Astro documentation site and deploy GitHub Pages. |
+| `build-check.yml` | Pull requests to `main`, manual dispatch | Filters runtime-relevant changes, builds the Go application, starts the root Docker Compose stack for `/healthz`, and fails on an unhealthy response. |
+| `main-release.yml` | Push to `main`, manual dispatch | Builds amd64 and arm64 GHCR images, merges a multi-arch `latest` manifest, runs the prod compose health check, and runs k6 with report artifact upload. |
+| `codeql.yml` | Push to `main`, pull requests to `main`, weekly schedule | Runs Go CodeQL with manual build mode when source/workflow paths are relevant. |
+| `deploy.yml` | Push to `main`, manual dispatch | Uses the shared Pages docs workflow with Bun to build `docs/` and deploy GitHub Pages. |
 
 ## Release path
 
 ```text
 pull request
-  └─ build-check.yml
-       └─ merge to main
-            ├─ main-release.yml  -> GHCR image + k6 evidence
+  ├─ build-check.yml      -> Go build + root compose /healthz when runtime paths changed
+  └─ codeql.yml           -> Go security analysis when source paths changed
+       └─ rebase merge to main
+            ├─ main-release.yml  -> GHCR latest/latest-arm64 + k6 artifact
             ├─ codeql.yml        -> security analysis
-            └─ deploy.yml        -> GitHub Pages documentation
+            └─ deploy.yml        -> Astro docs to GitHub Pages
 ```
 
 ## Published artifacts
@@ -27,9 +28,11 @@ pull request
 - Documentation: [jonathanperis.github.io/rinha2-back-end-go/docs/](https://jonathanperis.github.io/rinha2-back-end-go/docs/)
 - Stress reports: [jonathanperis.github.io/rinha2-back-end-go/reports/](https://jonathanperis.github.io/rinha2-back-end-go/reports/)
 - Container image: `ghcr.io/jonathanperis/rinha2-back-end-go:latest`
+- Arm64 staging tag before manifest merge: `ghcr.io/jonathanperis/rinha2-back-end-go:latest-arm64`
 
 ## Operator notes
 
-- PR checks protect the documentation and runtime from obvious regressions.
-- Main-branch workflows are the deployment path; the live docs update after the GitHub Pages workflow finishes.
+- PR checks are path-filtered: docs-only changes may not run runtime Docker checks, but Pages still builds on `main` after merge.
+- Main-branch workflows are the deployment path; the live docs update after `deploy.yml` finishes.
 - Stress-test reports should be treated as run-specific evidence, not timeless proof of a single absolute ranking.
+- The production compose file reads SQL/NGINX config from `prod/conf/`; the development compose file reads from the repository root.

--- a/docs/wiki/getting-started.md
+++ b/docs/wiki/getting-started.md
@@ -2,10 +2,10 @@
 
 ## Prerequisites
 
-- Docker with Docker Compose.
+- Docker with Docker Compose and a reachable Docker daemon.
 - A shell with `curl` for quick smoke tests.
 
-> The full benchmark stack depends on a reachable Docker daemon. In this Hermes environment the Docker CLI exists, but daemon access is not available, so local compose verification must run on a machine with Docker permissions.
+> The full benchmark stack depends on Docker daemon access. In this Hermes environment the Docker CLI exists, but daemon access is not available, so local compose verification must run in CI or on a machine with Docker permissions.
 
 ## Clone and run
 
@@ -19,12 +19,16 @@ The API is exposed through NGINX at `http://localhost:9999`.
 
 ## Smoke-test the API
 
+Check the health endpoint used by CI:
+
+```bash
+curl -i http://localhost:9999/healthz
+```
+
 Create a credit transaction:
 
 ```bash
-curl -sS -X POST http://localhost:9999/clientes/1/transacoes \
-  -H "Content-Type: application/json" \
-  -d '{"valor": 1000, "tipo": "c", "descricao": "deposito"}'
+curl -sS -X POST http://localhost:9999/clientes/1/transacoes   -H "Content-Type: application/json"   -d '{"valor": 1000, "tipo": "c", "descricao": "deposito"}'
 ```
 
 Read the statement:
@@ -36,9 +40,7 @@ curl -sS http://localhost:9999/clientes/1/extrato
 Try an invalid debit to confirm validation still rejects overdrafts beyond the credit limit:
 
 ```bash
-curl -i -X POST http://localhost:9999/clientes/1/transacoes \
-  -H "Content-Type: application/json" \
-  -d '{"valor": 999999999, "tipo": "d", "descricao": "limite"}'
+curl -i -X POST http://localhost:9999/clientes/1/transacoes   -H "Content-Type: application/json"   -d '{"valor": 999999999, "tipo": "d", "descricao": "limite"}'
 ```
 
 ## Useful compose targets
@@ -47,12 +49,22 @@ curl -i -X POST http://localhost:9999/clientes/1/transacoes \
 |---------|-----|
 | `docker compose up nginx -d --build` | Build and start the challenge-counted stack behind NGINX. |
 | `docker compose logs -f nginx webapi1-go webapi2-go db` | Follow request path and database startup logs. |
-| `docker compose up k6` | Run the configured k6 service after the API is healthy. |
+| `docker compose up k6 --build --force-recreate` | Run the configured k6 service after the API is healthy. Root compose runs `MODE=dev`; prod compose runs `MODE=prod`. |
 | `docker compose down -v` | Stop services and remove the database volume for a clean run. |
 
 ## Endpoint summary
 
 | Endpoint | Method | Payload / response |
 |----------|--------|--------------------|
-| `/clientes/{id}/transacoes` | `POST` | JSON body with `valor`, `tipo`, and `descricao`. Returns updated `limite` and `saldo`. |
-| `/clientes/{id}/extrato` | `GET` | Returns `saldo` metadata and recent `ultimas_transacoes`. |
+| `/healthz` | `GET` | Returns `Healthy`; used by compose/CI health checks. |
+| `/clientes/{id}/transacoes` | `POST` | JSON body with `valor`, `tipo`, and `descricao`. Returns `id`, `limite`, and updated `saldo`. |
+| `/clientes/{id}/extrato` | `GET` | Returns `saldo` metadata and up to 10 recent `ultimas_transacoes`. |
+
+## Local Go build
+
+```bash
+cd src/WebApi
+go build -ldflags="-s -w" -o rinha2-back-end-go .
+```
+
+The binary requires `DATABASE_URL`; inside the Docker network it should point at the `db` service with credentials matching the compose/PostgreSQL environment.

--- a/docs/wiki/home.md
+++ b/docs/wiki/home.md
@@ -4,13 +4,13 @@ title: Home
 
 # Documentation
 
-Operator notes for the Go 1.25 Rinha de Backend 2024/Q1 implementation. The docs are split into short pages so each route has one job: understand the challenge, inspect the runtime shape, run the stack, read the performance evidence, or follow the CI pipeline.
+Operator notes for the Go 1.25.0 Rinha de Backend 2024/Q1 implementation. These pages are source-backed against the current repository: the Go API lives in `src/WebApi/main.go`, compose topology in `docker-compose.yml` and `prod/docker-compose.yml`, database functions in `docker-entrypoint-initdb.d/rinha.dump.sql`, and the docs routes in `docs/src/lib/sidebar.config.ts`.
 
 <div class="docs-status-grid">
-  <div class="status-tile"><span>Runtime</span><strong>Go 1.25</strong></div>
+  <div class="status-tile"><span>Runtime</span><strong>Go 1.25.0</strong></div>
   <div class="status-tile"><span>Resource cap</span><strong>1.5 CPU</strong></div>
   <div class="status-tile"><span>Memory cap</span><strong>550MB</strong></div>
-  <div class="status-tile"><span>API shape</span><strong>2 routes</strong></div>
+  <div class="status-tile"><span>Implemented endpoints</span><strong>3 routes</strong></div>
 </div>
 
 ## Start here
@@ -19,22 +19,22 @@ Operator notes for the Go 1.25 Rinha de Backend 2024/Q1 implementation. The docs
   <div class="doc-card">
     <span>01 · challenge</span>
     <a href="challenge/">Read the contest contract</a>
-    <p>Required endpoints, client model, resource limits, and the source specification.</p>
+    <p>Required banking endpoints, client model, validation rules, and resource limits.</p>
   </div>
   <div class="doc-card">
     <span>02 · architecture</span>
     <a href="architecture/">Inspect the runtime topology</a>
-    <p>NGINX least-connection balancing, two Go API containers, PostgreSQL stored procedures, and observability services.</p>
+    <p>NGINX least-connection balancing, two Go API containers, PostgreSQL stored procedures, and dev-only observability services.</p>
   </div>
   <div class="doc-card">
     <span>03 · getting started</span>
     <a href="getting-started/">Run the local stack</a>
-    <p>Clone, compose, smoke-test transactions, and query statements through port 9999.</p>
+    <p>Clone, compose, health-check, smoke-test transactions, and query statements through port 9999.</p>
   </div>
   <div class="doc-card">
     <span>04 · performance</span>
     <a href="performance/">Review benchmark evidence</a>
-    <p>Resource envelope, published report links, and the meaning of the headline claims.</p>
+    <p>Resource envelope, report archive, and the limits of historical benchmark claims.</p>
   </div>
 </div>
 
@@ -42,12 +42,13 @@ Operator notes for the Go 1.25 Rinha de Backend 2024/Q1 implementation. The docs
 
 | Signal | Value | Source |
 |--------|-------|--------|
-| Language | Go 1.25 | `README.md`, site metadata |
-| Router | chi/v5 | `go.mod`, API implementation |
-| Database client | pgx/v5 with pgxpool | `go.mod`, API implementation |
-| Database strategy | PostgreSQL stored procedures | `docker-entrypoint-initdb.d/` |
-| Load balancer | NGINX `least_conn` | `nginx.conf` |
-| Reports | Static k6 HTML archive | `docs/public/reports/` |
+| Language | Go 1.25.0 | `src/WebApi/go.mod` |
+| Router | chi/v5.2.5 | `go.mod`, `main.go` |
+| Database client | pgx/v5.9.2 with `pgxpool` | `go.mod`, `main.go` |
+| Database strategy | PostgreSQL stored procedures over UNLOGGED tables | `docker-entrypoint-initdb.d/rinha.dump.sql` |
+| Load balancer | NGINX `least_conn` on port 9999 | `nginx.conf` |
+| API endpoints | `/healthz`, `/clientes/{id}/transacoes`, `/clientes/{id}/extrato` | `src/WebApi/main.go` |
+| Reports | 34 committed k6 HTML reports | `docs/public/reports/` |
 
 ## Fast path
 
@@ -55,6 +56,7 @@ Operator notes for the Go 1.25 Rinha de Backend 2024/Q1 implementation. The docs
 git clone https://github.com/jonathanperis/rinha2-back-end-go.git
 cd rinha2-back-end-go
 docker compose up nginx -d --build
+curl http://localhost:9999/healthz
 curl http://localhost:9999/clientes/1/extrato
 ```
 

--- a/docs/wiki/performance.md
+++ b/docs/wiki/performance.md
@@ -4,15 +4,18 @@
 
 The project targets the official Rinha de Backend 2024/Q1 limit of **1.5 CPU** and **550MB RAM** across the challenge-counted stack.
 
-| Metric | Limit | Documented result | Margin |
-|--------|-------|-------------------|--------|
-| RAM | 550MB | ~250MB | About 60% below the limit |
-| Response time | Challenge-sensitive | < 800ms | All documented requests under the headline threshold |
-| API replicas | 2 | 2 | Balanced by NGINX `least_conn` |
+| Metric | Limit / shape | Current source-backed value |
+|--------|---------------|-----------------------------|
+| RAM | 550MB | Compose limits total 550MB: API x2 100MB, NGINX 20MB, DB 330MB. |
+| CPU | 1.5 | Compose limits total 1.5: API x2 0.4, NGINX 0.2, DB 0.5. |
+| API replicas | Challenge implementation choice | 2 Go containers balanced by NGINX `least_conn`. |
+| Reports | Historical evidence | 34 committed k6 HTML reports under `docs/public/reports/`. |
+
+Older reports and homepage copy may mention headline latency/resource observations from specific runs. Treat those as historical evidence, not a timeless guarantee: benchmark numbers vary by host, runner, image version, and workload timing.
 
 ## Published reports
 
-Stress-test HTML reports are published with the static site under [`/reports/`](../reports/). Use them as the durable evidence trail for individual runs rather than treating a single number as universal performance truth.
+Stress-test HTML reports are published with the static site under [`/reports/`](../../reports/). Use them as the durable evidence trail for individual runs rather than treating a single number as universal performance truth.
 
 ## How to read the results
 
@@ -33,7 +36,7 @@ Stress-test HTML reports are published with the static site under [`/reports/`](
 
 ```bash
 docker compose up nginx -d --build
-docker compose up k6
+docker compose up k6 --build --force-recreate
 ```
 
-For development dashboards, start the observability services too and keep the k6 service in development mode. For publishable evidence, prefer the generated HTML reports that are archived by the site.
+For development dashboards, use the root compose file and its observability services. For publishable evidence, prefer the generated HTML reports archived by the site or uploaded by `main-release.yml`.


### PR DESCRIPTION
## Summary
- Audited the root README, docs README, and every `docs/wiki/*.md` page against the current Go code, compose files, SQL dump, workflows, and Astro docs renderer.
- Replaced stale/general claims with source-backed facts for Go/dependency versions, endpoints including `/healthz`, validation behavior, resource limits, Docker images, workflows, report archive count, and docs routing.
- Fixed a rendered internal report link from the nested Performance docs page.

## Verification
- [x] `git diff --check`
- [x] `cd src/WebApi && go test ./...`
- [x] `cd docs && bun run lint`
- [x] `cd docs && NODE_ENV=production bun run build`
- [x] Rendered docs marker checks for home, architecture, CI/CD, getting-started, and reports pages
- [x] Generated-site internal link check (`docs/out/**/*.html`)
