### PR TITLE
docs: add source-backed audit notes

### DIFF
--- a/README.md
+++ b/README.md
@@ -65,7 +65,7 @@ Transaction validation in `main.go` currently requires:
 - `tipo` exactly `c` or `d`.
 - `descricao` non-empty and at most 10 characters.
 - `valor` greater than zero.
-- Debits are accepted by the stored procedure only when the resulting balance is not below `-Limite`; credits are always allowed.
+- Debits call `InsertTransacao`; an over-limit debit does not mutate the balance and currently returns the unchanged balance unless the database call itself fails.
 
 ## Getting started
 
@@ -121,6 +121,8 @@ Published image tags:
 ## Documentation
 
 The public docs are generated from `docs/wiki/*.md` via `docs/src/pages/docs/[...slug].astro`. The route set is defined in `docs/src/lib/sidebar.config.ts`, and the stress report index reads committed HTML reports from `docs/public/reports/`.
+
+The [Source Audit](https://jonathanperis.github.io/rinha2-back-end-go/docs/audit/) page tracks repo-vs-docs details that are easy to miss, including current over-limit debit behavior, statement transaction fields, dev/prod compose differences, and PR path-filter boundaries.
 
 ## License
 

--- a/docs/src/lib/sidebar.config.ts
+++ b/docs/src/lib/sidebar.config.ts
@@ -1,7 +1,7 @@
 export const SECTION_CATEGORIES = [
   { label: '', ids: ['home'] },
   { label: 'Overview', ids: ['challenge', 'architecture'] },
-  { label: 'Develop', ids: ['getting-started', 'performance', 'ci-cd-pipeline'] },
+  { label: 'Develop', ids: ['getting-started', 'performance', 'ci-cd-pipeline', 'audit'] },
 ] as const;
 
 export const SECTION_ORDER = SECTION_CATEGORIES.flatMap(({ ids }) => ids);

--- a/docs/src/pages/docs/[...slug].astro
+++ b/docs/src/pages/docs/[...slug].astro
@@ -10,6 +10,7 @@ const SLUG_LABEL: Record<string, string> = {
   'ci-cd-pipeline': 'CI/CD Pipeline',
   'getting-started': 'Getting Started',
   performance: 'Performance',
+  audit: 'Source Audit',
 };
 
 const globResult = import.meta.glob('../../../wiki/*.md', { eager: true });

--- a/docs/wiki/audit.md
+++ b/docs/wiki/audit.md
@@ -15,7 +15,83 @@ This page records the repo-vs-docs audit points that are easy to miss when readi
 | Binary startup | Running the Go binary outside compose requires `DATABASE_URL`; compose injects the service connection string. | `main.go`, compose files |
 | PR filters | Pull-request runtime checks are path-filtered. Docs-only changes usually skip Docker runtime checks; `prod/**` changes are not part of the PR health filter today, while main-branch workflows still deploy Pages and run release checks. | `.github/workflows/*.yml` |
 
-## Behaviors to document carefully
+## Current API contract
+
+### `GET /healthz`
+
+Used by Docker Compose and CI as a readiness smoke check.
+
+```http
+HTTP/1.1 200 OK
+
+Healthy
+```
+
+### `POST /clientes/{id}/transacoes`
+
+Request body accepted by the Go handler:
+
+```json
+{
+  "valor": 1000,
+  "tipo": "c",
+  "descricao": "deposito"
+}
+```
+
+Successful response shape:
+
+```json
+{
+  "id": 1,
+  "limite": 100000,
+  "saldo": 1000
+}
+```
+
+Validation and error behavior currently implemented:
+
+| Case | Status | Source-backed note |
+|---|---:|---|
+| Non-integer `{id}` | `400` | `strconv.Atoi` failure in `postTransacaoHandler`. |
+| Unknown client ID | `404` | Client not found in the in-memory `clientes` map. |
+| Invalid JSON | `400` | JSON decode failure. |
+| Invalid `tipo`, empty/long `descricao`, or non-positive `valor` | `422` | `isTransacaoValid` failure. |
+| Over-limit debit | `200` | `InsertTransacao` refuses the mutation and returns the existing balance; the handler serializes that value. |
+| Database/query failure | `500` | Handler returns the database error as an internal server error. |
+
+### `GET /clientes/{id}/extrato`
+
+Successful response shape currently emitted by Go:
+
+```json
+{
+  "saldo": {
+    "total": 1000,
+    "limite": 100000,
+    "data_extrato": "2026-05-29T22:00:00Z"
+  },
+  "ultimas_transacoes": [
+    {
+      "valor": 1000,
+      "tipo": "c",
+      "descricao": "deposito"
+    }
+  ]
+}
+```
+
+Statement error behavior currently implemented:
+
+| Case | Status | Source-backed note |
+|---|---:|---|
+| Non-integer `{id}` | `400` | `strconv.Atoi` failure in `getExtratoHandler`. |
+| Unknown client ID | `404` | Client not found in the in-memory `clientes` map. |
+| Database row missing | `404` | Defensive `sql.ErrNoRows` branch after the stored-function call. |
+| Database/query failure | `500` | Handler returns the database error as an internal server error. |
+| Transaction JSON unmarshal failure | `200` | Handler logs the failure and emits an empty `ultimas_transacoes` array. |
+
+## Behaviors that differ from the original challenge shape
 
 ### Over-limit debits
 
@@ -26,7 +102,7 @@ That means the current implementation behavior is:
 - malformed client IDs: `400`
 - unknown client IDs: `404`
 - invalid transaction fields: `422`
-- over-limit debit: no balance mutation; current balance returned by the stored procedure
+- over-limit debit: no balance mutation; current balance returned by the stored procedure with `200`
 
 If strict challenge compatibility requires a `422` for over-limit debits, that is an implementation follow-up rather than a docs-only change.
 
@@ -36,15 +112,47 @@ The SQL function includes `RealizadoEm` in the JSON row source, but the Go respo
 
 If the project wants full challenge response parity, add a timestamp field to `TransacaoDto` with the expected JSON name and then update the docs.
 
-### Dev stack versus prod stack
+## Runtime stacks
 
-The root compose file is the local/dev stack: it builds the Go image from source, exposes direct API ports `4200` and `4201`, and includes Grafana, Prometheus, InfluxDB, postgres-exporter, and the k6 service in `MODE=dev`.
+### Development/root compose
 
-The `prod/` compose file is the CI/release stack: it consumes the GHCR image, maps API containers to `8081` and `8082`, uses config from `prod/conf/`, and runs k6 in `MODE=prod` with an HTML report artifact.
+The root compose file is the local/dev stack:
 
-## Documentation follow-ups worth considering
+- builds the Go image from `src/WebApi/Dockerfile`
+- exposes NGINX at `localhost:9999`
+- exposes direct API containers on `4200` and `4201`
+- runs two API containers behind NGINX `least_conn`
+- includes PostgreSQL, Grafana, Prometheus, InfluxDB, postgres-exporter, and k6
+- runs k6 with `MODE=dev`
 
-- Add exact example response bodies once the API shape is considered stable.
-- Decide whether over-limit debit should remain a documented current behavior or be changed to return `422`.
-- Decide whether statement transactions should expose the stored `RealizadoEm` timestamp.
-- Consider extending PR path filters if prod compose/config changes should run the same runtime health gate before merge.
+### Production/release compose
+
+The `prod/` compose file is the CI/release stack:
+
+- consumes the GHCR image instead of building from local source
+- maps API containers to `8081` and `8082`
+- uses config from `prod/conf/`
+- runs k6 with `MODE=prod`
+- writes the HTML stress report uploaded by `main-release.yml`
+
+## CI/CD boundaries
+
+Pull-request checks are intentionally path-filtered:
+
+- `build-check.yml` watches `src/**`, root Go/Docker/Compose inputs, and its workflow file.
+- CodeQL watches `src/**`, root Go module files, and its workflow file.
+- Docs-only changes usually skip Docker runtime jobs.
+- `prod/**` changes are not part of the PR runtime health filter today; they are exercised by `main-release.yml` after merge to `main`.
+
+Main-branch flows remain the deployment and release path:
+
+- `deploy.yml` publishes the Astro static site to GitHub Pages.
+- `main-release.yml` builds/pushes the GHCR image, runs prod compose health checks, runs k6, and uploads the stress-test report artifact.
+
+## Implementation decisions still open
+
+These are now documented, not hidden, but they are implementation choices the project may still want to change later:
+
+- Whether over-limit debits should keep returning unchanged balance with `200` or be changed to strict `422` behavior.
+- Whether `ultimas_transacoes` should expose the stored `RealizadoEm` timestamp for full challenge response parity.
+- Whether PR path filters should include `prod/**` and `prod/conf/**` so release-stack config changes run the runtime health gate before merge.

--- a/docs/wiki/audit.md
+++ b/docs/wiki/audit.md
@@ -1,0 +1,50 @@
+# Source Audit
+
+## Why this page exists
+
+This page records the repo-vs-docs audit points that are easy to miss when reading only the README or landing page. It is source-backed against the current Go handlers, SQL functions, compose files, and GitHub Actions workflows.
+
+## Confirmed implementation facts
+
+| Area | Source-backed behavior | Source |
+|---|---|---|
+| HTTP routes | The API exposes `GET /healthz`, `GET /clientes/{id}/extrato`, and `POST /clientes/{id}/transacoes`. | `src/WebApi/main.go` |
+| Server timeouts | The HTTP server uses a 5-second read timeout, 10-second write timeout, and 5-second DB context timeout per handler call. | `src/WebApi/main.go` |
+| Client limits | Clients 1–5 are defined in both Go and SQL with limits `100000`, `80000`, `1000000`, `10000000`, and `500000`. | `main.go`, `rinha.dump.sql` |
+| Statement rows | PostgreSQL stores `RealizadoEm` and selects it in the statement function, but the Go `TransacaoDto` currently serializes only `valor`, `tipo`, and `descricao`. | `rinha.dump.sql`, `main.go` |
+| Binary startup | Running the Go binary outside compose requires `DATABASE_URL`; compose injects the service connection string. | `main.go`, compose files |
+| PR filters | Pull-request runtime checks are path-filtered. Docs-only changes usually skip Docker runtime checks; `prod/**` changes are not part of the PR health filter today, while main-branch workflows still deploy Pages and run release checks. | `.github/workflows/*.yml` |
+
+## Behaviors to document carefully
+
+### Over-limit debits
+
+The Go handler validates JSON shape, `tipo`, `descricao`, and positive `valor` before calling PostgreSQL. The stored procedure refuses to apply a debit that would exceed the negative credit limit, but it returns the current balance instead of raising an error. The handler then serializes that balance with HTTP `200` unless the database call itself fails.
+
+That means the current implementation behavior is:
+
+- malformed client IDs: `400`
+- unknown client IDs: `404`
+- invalid transaction fields: `422`
+- over-limit debit: no balance mutation; current balance returned by the stored procedure
+
+If strict challenge compatibility requires a `422` for over-limit debits, that is an implementation follow-up rather than a docs-only change.
+
+### Statement transaction timestamp
+
+The SQL function includes `RealizadoEm` in the JSON row source, but the Go response DTO has no timestamp field. The public statement response currently documents the stable fields emitted by Go: `valor`, `tipo`, and `descricao` inside `ultimas_transacoes`.
+
+If the project wants full challenge response parity, add a timestamp field to `TransacaoDto` with the expected JSON name and then update the docs.
+
+### Dev stack versus prod stack
+
+The root compose file is the local/dev stack: it builds the Go image from source, exposes direct API ports `4200` and `4201`, and includes Grafana, Prometheus, InfluxDB, postgres-exporter, and the k6 service in `MODE=dev`.
+
+The `prod/` compose file is the CI/release stack: it consumes the GHCR image, maps API containers to `8081` and `8082`, uses config from `prod/conf/`, and runs k6 in `MODE=prod` with an HTML report artifact.
+
+## Documentation follow-ups worth considering
+
+- Add exact example response bodies once the API shape is considered stable.
+- Decide whether over-limit debit should remain a documented current behavior or be changed to return `422`.
+- Decide whether statement transactions should expose the stored `RealizadoEm` timestamp.
+- Consider extending PR path filters if prod compose/config changes should run the same runtime health gate before merge.

--- a/docs/wiki/challenge.md
+++ b/docs/wiki/challenge.md
@@ -35,7 +35,7 @@ Current validation is split between Go and PostgreSQL:
 - `tipo` must be exactly debit (`d`) or credit (`c`).
 - `descricao` must be non-empty and at most 10 characters.
 - `valor` must be greater than zero.
-- Debits cannot push the balance below `-Limite`; credits are allowed unconditionally.
+- Debits cannot push the balance below `-Limite`; the current stored procedure refuses the mutation and returns the existing balance, so the Go handler responds with the unchanged balance unless the database call itself fails.
 - Invalid transaction fields return `422`.
 
 ## Resource constraints

--- a/docs/wiki/challenge.md
+++ b/docs/wiki/challenge.md
@@ -9,9 +9,42 @@ Rinha de Backend is a Brazilian backend programming challenge. The 2024/Q1 editi
 | Endpoint | Method | Expected behavior | Current implementation note |
 |----------|--------|-------------------|-----------------------------|
 | `/clientes/{id}/transacoes` | `POST` | Submit a debit (`d`) or credit (`c`) transaction for clients 1 through 5. | Implemented in `postTransacaoHandler`; returns `id`, `limite`, and updated `saldo`. |
-| `/clientes/{id}/extrato` | `GET` | Return current balance, credit limit, statement timestamp, and recent transactions. | Implemented in `getExtratoHandler`; returns `saldo` and up to 10 `ultimas_transacoes`. |
+| `/clientes/{id}/extrato` | `GET` | Return current balance, credit limit, statement timestamp, and recent transactions. | Implemented in `getExtratoHandler`; returns `saldo` and up to 10 `ultimas_transacoes`. Current transaction rows serialize `valor`, `tipo`, and `descricao`; `RealizadoEm` is stored/selected in SQL but not exposed by the Go DTO. |
 
 The repository also exposes `GET /healthz` for compose/CI health checks; it is not part of the original banking contract.
+
+### Current response shapes
+
+`POST /clientes/{id}/transacoes` returns:
+
+```json
+{
+  "id": 1,
+  "limite": 100000,
+  "saldo": 1000
+}
+```
+
+`GET /clientes/{id}/extrato` returns:
+
+```json
+{
+  "saldo": {
+    "total": 1000,
+    "limite": 100000,
+    "data_extrato": "2026-05-29T22:00:00Z"
+  },
+  "ultimas_transacoes": [
+    {
+      "valor": 1000,
+      "tipo": "c",
+      "descricao": "deposito"
+    }
+  ]
+}
+```
+
+See [Source Audit](../audit/) for the complete status-code matrix and edge cases.
 
 ## Seeded clients
 

--- a/docs/wiki/ci-cd-pipeline.md
+++ b/docs/wiki/ci-cd-pipeline.md
@@ -32,7 +32,7 @@ pull request
 
 ## Operator notes
 
-- PR checks are path-filtered: docs-only changes may not run runtime Docker checks, but Pages still builds on `main` after merge.
+- `build-check.yml` and CodeQL are path-filtered on pull requests. The current runtime health gate watches source/root-compose paths, while `prod/**` changes are exercised by the `main-release.yml` path after merge.
 - Main-branch workflows are the deployment path; the live docs update after `deploy.yml` finishes.
 - Stress-test reports should be treated as run-specific evidence, not timeless proof of a single absolute ranking.
 - The production compose file reads SQL/NGINX config from `prod/conf/`; the development compose file reads from the repository root.

--- a/docs/wiki/getting-started.md
+++ b/docs/wiki/getting-started.md
@@ -60,6 +60,39 @@ curl -i -X POST http://localhost:9999/clientes/1/transacoes   -H "Content-Type: 
 | `/clientes/{id}/transacoes` | `POST` | JSON body with `valor`, `tipo`, and `descricao`. Returns `id`, `limite`, and updated `saldo`. |
 | `/clientes/{id}/extrato` | `GET` | Returns `saldo` metadata and up to 10 recent `ultimas_transacoes`; the current Go DTO serializes transaction `valor`, `tipo`, and `descricao`. |
 
+## Current response examples
+
+Transaction response:
+
+```json
+{
+  "id": 1,
+  "limite": 100000,
+  "saldo": 1000
+}
+```
+
+Statement response:
+
+```json
+{
+  "saldo": {
+    "total": 1000,
+    "limite": 100000,
+    "data_extrato": "2026-05-29T22:00:00Z"
+  },
+  "ultimas_transacoes": [
+    {
+      "valor": 1000,
+      "tipo": "c",
+      "descricao": "deposito"
+    }
+  ]
+}
+```
+
+For the full status-code matrix and source-backed edge cases, see [Source Audit](../audit/).
+
 ## Local Go build
 
 ```bash

--- a/docs/wiki/getting-started.md
+++ b/docs/wiki/getting-started.md
@@ -37,7 +37,7 @@ Read the statement:
 curl -sS http://localhost:9999/clientes/1/extrato
 ```
 
-Try an invalid debit to confirm validation still rejects overdrafts beyond the credit limit:
+Try an over-limit debit to confirm the current database behavior: the stored procedure refuses the balance mutation and returns the existing balance. This is documented as current behavior on the source-audit page rather than as a strict `422` validation response.
 
 ```bash
 curl -i -X POST http://localhost:9999/clientes/1/transacoes   -H "Content-Type: application/json"   -d '{"valor": 999999999, "tipo": "d", "descricao": "limite"}'
@@ -58,7 +58,7 @@ curl -i -X POST http://localhost:9999/clientes/1/transacoes   -H "Content-Type: 
 |----------|--------|--------------------|
 | `/healthz` | `GET` | Returns `Healthy`; used by compose/CI health checks. |
 | `/clientes/{id}/transacoes` | `POST` | JSON body with `valor`, `tipo`, and `descricao`. Returns `id`, `limite`, and updated `saldo`. |
-| `/clientes/{id}/extrato` | `GET` | Returns `saldo` metadata and up to 10 recent `ultimas_transacoes`. |
+| `/clientes/{id}/extrato` | `GET` | Returns `saldo` metadata and up to 10 recent `ultimas_transacoes`; the current Go DTO serializes transaction `valor`, `tipo`, and `descricao`. |
 
 ## Local Go build
 

--- a/docs/wiki/home.md
+++ b/docs/wiki/home.md
@@ -36,6 +36,11 @@ Operator notes for the Go 1.25.0 Rinha de Backend 2024/Q1 implementation. These 
     <a href="performance/">Review benchmark evidence</a>
     <p>Resource envelope, report archive, and the limits of historical benchmark claims.</p>
   </div>
+  <div class="doc-card">
+    <span>05 · source audit</span>
+    <a href="audit/">Check implementation/documentation edges</a>
+    <p>Over-limit debit behavior, statement fields, compose differences, and path-filter boundaries.</p>
+  </div>
 </div>
 
 ## Implementation snapshot


### PR DESCRIPTION
## Summary
- Add a routed Source Audit docs page for code-vs-docs edge cases
- Correct README/docs wording for current over-limit debit behavior
- Document current statement transaction fields, dev/prod compose differences, `DATABASE_URL`, and PR path-filter boundaries
- Expand the audit/guide pages with concrete API response examples, status-code matrices, runtime stack boundaries, CI/CD boundaries, and remaining implementation decisions

## Audit findings documented
- Over-limit debits currently do not mutate balance and return the existing balance with `200` unless the DB call fails
- SQL stores/selects `RealizadoEm`, but Go `TransacaoDto` currently serializes only `valor`, `tipo`, and `descricao`
- Running the binary outside Compose requires `DATABASE_URL`
- Root compose is the development/observability stack; `prod/` compose is the release/runtime stack
- PR runtime filters do not include `prod/**`; prod config is exercised by `main-release.yml` after merge

## Validation
- [x] Source-backed semantic audit script
- [x] `bun run lint`
- [x] `NODE_ENV=production bun run build`
- [x] generated HTML internal link check: 43 HTML files, 0 broken internal links
- [x] local production-base preview smoke for `/docs/audit/`, `/docs/getting-started/`, and `/docs/challenge/`
